### PR TITLE
fix: correct dev and build commands in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,14 +30,13 @@ Prerequisites: [Node.js](https://nodejs.org/) 20+, [Rust](https://www.rust-lang.
 
 ```bash
 npm install
-npm run dev          # Vite dev server + Tauri window
+npx tauri dev        # Vite dev server + Tauri window
 ```
 
 ### Build
 
 ```bash
-npm run build
-cd src-tauri && cargo build
+npx tauri build
 ```
 
 ### Release


### PR DESCRIPTION
## Summary
- `npm run dev` only starts the Vite frontend server, not the full Tauri app
- Changed dev command from `npm run dev` to `npx tauri dev`
- Changed build command from `npm run build && cd src-tauri && cargo build` to `npx tauri build`