### PR TITLE
fix: skip wildcard channel IDs in Discord guild channel collection

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -817,6 +817,10 @@ pub async fn refresh_discord_guild_channels() -> Result<Vec<DiscordGuildChannel>
 
                 if let Some(channels) = guild_val.get("channels").and_then(Value::as_object) {
                     for (channel_id, _channel_val) in channels {
+                        // Skip glob/wildcard patterns (e.g. "*") — not real channel IDs
+                        if channel_id.contains('*') || channel_id.contains('?') {
+                            continue;
+                        }
                         if entries.iter().any(|e| e.guild_id == *guild_id && e.channel_id == *channel_id) {
                             continue;
                         }
@@ -4950,6 +4954,10 @@ pub async fn remote_list_discord_guild_channels(
 
             if let Some(channels) = guild_val.get("channels").and_then(Value::as_object) {
                 for (channel_id, _) in channels {
+                    // Skip glob/wildcard patterns (e.g. "*") — not real channel IDs
+                    if channel_id.contains('*') || channel_id.contains('?') {
+                        continue;
+                    }
                     if entries.iter().any(|e| e.guild_id == *guild_id && e.channel_id == *channel_id) {
                         continue;
                     }


### PR DESCRIPTION
When config uses glob patterns like '*' as channel keys (e.g. channels: { '*': { allow: true } }), the collect_guilds helper was treating '*' as a real Discord channel ID. This prevented the Discord API fallback from triggering, resulting in wildcard entries displayed as raw '*' with no channel name resolution.

Skip channel IDs containing '*' or '?' so the fallback path correctly fetches actual channels from the Discord REST API.

Affects both local and remote (SSH) channel discovery paths.