### PR TITLE
ci: add test workflow for frontend and Rust

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,75 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+      - develop
+  pull_request:
+    branches:
+      - main
+      - develop
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  frontend:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Install frontend dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Type check
+        run: bun run typecheck
+
+      - name: Build
+        run: bun run build
+
+  rust:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            libappindicator3-dev \
+            librsvg2-dev \
+            patchelf \
+            libssl-dev \
+            libgtk-3-dev \
+            libsoup-3.0-dev \
+            libjavascriptcoregtk-4.1-dev
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+        working-directory: src-tauri
+
+      - name: Run clippy
+        run: cargo clippy -p clawpal-core -- -D warnings
+        working-directory: src-tauri
+
+      - name: Run tests
+        run: cargo test -p clawpal-core
+        working-directory: src-tauri

--- a/clawpal-core/src/install/mod.rs
+++ b/clawpal-core/src/install/mod.rs
@@ -48,10 +48,11 @@ pub enum InstallError {
 pub type Result<T> = std::result::Result<T, InstallError>;
 
 pub fn install_docker(options: DockerInstallOptions) -> Result<InstallResult> {
-    let mut steps = Vec::new();
-    steps.push(docker::pull(&options)?);
-    steps.push(docker::configure(&options)?);
-    steps.push(docker::up(&options)?);
+    let steps = vec![
+        docker::pull(&options)?,
+        docker::configure(&options)?,
+        docker::up(&options)?,
+    ];
 
     let home = options
         .home

--- a/clawpal-core/src/profile.rs
+++ b/clawpal-core/src/profile.rs
@@ -322,7 +322,7 @@ fn fill_profile_auth_from_existing_or_provider_donor(
             if profile
                 .api_key
                 .as_ref()
-                .map_or(true, |key| key.trim().is_empty())
+                .is_none_or(|key| key.trim().is_empty())
             {
                 profile.api_key = existing.api_key.clone();
             }
@@ -341,7 +341,7 @@ fn fill_profile_auth_from_existing_or_provider_donor(
     if profile
         .api_key
         .as_ref()
-        .map_or(true, |key| key.trim().is_empty())
+        .is_none_or(|key| key.trim().is_empty())
     {
         if let Some(donor) = profiles.iter().find(|candidate| {
             candidate.provider.eq_ignore_ascii_case(provider)

--- a/clawpal-core/src/ssh/config.rs
+++ b/clawpal-core/src/ssh/config.rs
@@ -193,9 +193,7 @@ fn parse_ssh_config_entry(line: &str) -> Option<(String, String)> {
         }
     }
 
-    let Some((sep_idx, is_eq)) = sep else {
-        return None;
-    };
+    let (sep_idx, is_eq) = sep?;
 
     let key = line[..sep_idx].trim().to_ascii_lowercase();
     if key.is_empty() {

--- a/clawpal-core/src/ssh/mod.rs
+++ b/clawpal-core/src/ssh/mod.rs
@@ -250,7 +250,7 @@ impl SshSession {
                 let mut exit_code = -1;
                 while let Some(msg) = mkdir_ch.wait().await {
                     match msg {
-                        russh::ChannelMsg::ExtendedData { data, ext } if ext == 1 => {
+                        russh::ChannelMsg::ExtendedData { data, ext: 1 } => {
                             stderr.extend_from_slice(&data);
                         }
                         russh::ChannelMsg::ExitStatus { exit_status } => {
@@ -481,15 +481,17 @@ async fn connect_and_auth(
         let key_pair = passphrase
             .map(str::trim)
             .filter(|v| !v.is_empty())
-            .and_then(|phrase| {
-                match russh_keys::load_secret_key(&expanded, Some(phrase)) {
+            .and_then(
+                |phrase| match russh_keys::load_secret_key(&expanded, Some(phrase)) {
                     Ok(pair) => Some(pair),
                     Err(err) => {
-                        attempts.push(format!("{expanded}: encrypted or passphrase mismatch ({err})"));
+                        attempts.push(format!(
+                            "{expanded}: encrypted or passphrase mismatch ({err})"
+                        ));
                         None
                     }
-                }
-            })
+                },
+            )
             .or_else(|| match russh_keys::load_secret_key(&expanded, None) {
                 Ok(pair) => Some(pair),
                 Err(err) => {
@@ -520,10 +522,7 @@ async fn connect_and_auth(
     };
     Err(SshError::Auth(format!(
         "public key authentication failed for {}@{}:{} after trying {}",
-        resolved.username,
-        resolved.host,
-        resolved.port,
-        details
+        resolved.username, resolved.host, resolved.port, details
     )))
 }
 

--- a/src-tauri/src/agent_fallback.rs
+++ b/src-tauri/src/agent_fallback.rs
@@ -525,16 +525,11 @@ mod tests {
             "testModelProfile",
             None,
         );
-        assert!(
-            result.summary.contains("实例 `ssh:hetzner`")
-                || result.summary.contains("实例")
-        );
+        assert!(result.summary.contains("实例 `ssh:hetzner`") || result.summary.contains("实例"));
         assert!(result.actions.iter().any(|a| a.contains("重连")));
-        assert!(
-            result
-                .structured_actions
-                .iter()
-                .any(|a| a.action_type == "inline_fix" && a.tool.as_deref() == Some("clawpal"))
-        );
+        assert!(result
+            .structured_actions
+            .iter()
+            .any(|a| a.action_type == "inline_fix" && a.tool.as_deref() == Some("clawpal")));
     }
 }

--- a/src-tauri/src/commands/logs.rs
+++ b/src-tauri/src/commands/logs.rs
@@ -35,7 +35,9 @@ pub async fn remote_read_app_log(
 ) -> Result<String, String> {
     let n = clamp_lines(lines);
     let cmd = format!("tail -n {n} ~/.clawpal/logs/app.log 2>/dev/null || echo ''");
-    log_debug(&format!("remote_read_app_log start host_id={host_id} lines={n} cmd={cmd}"));
+    log_debug(&format!(
+        "remote_read_app_log start host_id={host_id} lines={n} cmd={cmd}"
+    ));
     let result = pool.exec(&host_id, &cmd).await.map_err(|error| {
         log_debug(&format!(
             "remote_read_app_log failed host_id={host_id} error={error}"
@@ -53,7 +55,9 @@ pub async fn remote_read_error_log(
 ) -> Result<String, String> {
     let n = clamp_lines(lines);
     let cmd = format!("tail -n {n} ~/.clawpal/logs/error.log 2>/dev/null || echo ''");
-    log_debug(&format!("remote_read_error_log start host_id={host_id} lines={n} cmd={cmd}"));
+    log_debug(&format!(
+        "remote_read_error_log start host_id={host_id} lines={n} cmd={cmd}"
+    ));
     let result = pool.exec(&host_id, &cmd).await.map_err(|error| {
         log_debug(&format!(
             "remote_read_error_log failed host_id={host_id} error={error}"
@@ -71,7 +75,9 @@ pub async fn remote_read_gateway_log(
 ) -> Result<String, String> {
     let n = clamp_lines(lines);
     let cmd = format!("tail -n {n} ~/.openclaw/logs/gateway.log 2>/dev/null || echo ''");
-    log_debug(&format!("remote_read_gateway_log start host_id={host_id} lines={n} cmd={cmd}"));
+    log_debug(&format!(
+        "remote_read_gateway_log start host_id={host_id} lines={n} cmd={cmd}"
+    ));
     let result = pool.exec(&host_id, &cmd).await.map_err(|error| {
         log_debug(&format!(
             "remote_read_gateway_log failed host_id={host_id} error={error}"

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -5728,28 +5728,20 @@ pub async fn ssh_connect(
     if hosts.is_empty() {
         crate::commands::logs::log_dev("[dev][ssh_connect] host registry is empty");
     }
-    let host = hosts
-        .into_iter()
-        .find(|h| h.id == host_id)
-        .ok_or_else(|| {
-            let mut ids = Vec::new();
-            for h in read_hosts_from_registry().unwrap_or_default() {
-                ids.push(h.id);
-            }
-            crate::commands::logs::log_dev(format!(
-                "[dev][ssh_connect] no host found host_id={host_id} known={ids:?}"
-            ));
-            format!("No SSH host config with id: {host_id}")
-        })?;
+    let host = hosts.into_iter().find(|h| h.id == host_id).ok_or_else(|| {
+        let mut ids = Vec::new();
+        for h in read_hosts_from_registry().unwrap_or_default() {
+            ids.push(h.id);
+        }
+        crate::commands::logs::log_dev(format!(
+            "[dev][ssh_connect] no host found host_id={host_id} known={ids:?}"
+        ));
+        format!("No SSH host config with id: {host_id}")
+    })?;
     if let Err(error) = pool.connect(&host).await {
         crate::commands::logs::log_dev(format!(
             "[dev][ssh_connect] failed host_id={} host={} user={} port={} auth_method={} error={}",
-            host_id,
-            host.host,
-            host.username,
-            host.port,
-            host.auth_method,
-            error
+            host_id, host.host, host.username, host.port, host.auth_method, error
         ));
         return Err(format!("ssh connect failed: {error}"));
     }
@@ -5774,24 +5766,22 @@ pub async fn ssh_connect_with_passphrase(
     }
     let hosts = read_hosts_from_registry()?;
     if hosts.is_empty() {
-        crate::commands::logs::log_dev(
-            "[dev][ssh_connect_with_passphrase] host registry is empty",
-        );
+        crate::commands::logs::log_dev("[dev][ssh_connect_with_passphrase] host registry is empty");
     }
-    let host = hosts
-        .into_iter()
-        .find(|h| h.id == host_id)
-        .ok_or_else(|| {
-            let mut ids = Vec::new();
-            for h in read_hosts_from_registry().unwrap_or_default() {
-                ids.push(h.id);
-            }
-            crate::commands::logs::log_dev(format!(
-                "[dev][ssh_connect_with_passphrase] no host found host_id={host_id} known={ids:?}"
-            ));
-            format!("No SSH host config with id: {host_id}")
-        })?;
-    if let Err(error) = pool.connect_with_passphrase(&host, Some(passphrase.as_str())).await {
+    let host = hosts.into_iter().find(|h| h.id == host_id).ok_or_else(|| {
+        let mut ids = Vec::new();
+        for h in read_hosts_from_registry().unwrap_or_default() {
+            ids.push(h.id);
+        }
+        crate::commands::logs::log_dev(format!(
+            "[dev][ssh_connect_with_passphrase] no host found host_id={host_id} known={ids:?}"
+        ));
+        format!("No SSH host config with id: {host_id}")
+    })?;
+    if let Err(error) = pool
+        .connect_with_passphrase(&host, Some(passphrase.as_str()))
+        .await
+    {
         crate::commands::logs::log_dev(format!(
             "[dev][ssh_connect_with_passphrase] failed host_id={} host={} user={} port={} auth_method={} error={}",
             host_id,

--- a/src-tauri/src/ssh.rs
+++ b/src-tauri/src/ssh.rs
@@ -79,8 +79,7 @@ impl SshConnectionPool {
             let message = error.to_string();
             crate::commands::logs::log_dev(format!(
                 "[dev][ssh_pool] connect_with_passphrase session connect failed id={} error={}",
-                config.id,
-                message
+                config.id, message
             ));
             message
         })?;
@@ -98,8 +97,7 @@ impl SshConnectionPool {
             .unwrap_or_else(|| "/root".to_string());
         crate::commands::logs::log_dev(format!(
             "[dev][ssh_pool] connect_with_passphrase resolved_home id={} home={}",
-            config.id,
-            home
+            config.id, home
         ));
 
         self.connections.lock().await.insert(
@@ -121,16 +119,13 @@ impl SshConnectionPool {
     }
 
     pub async fn disconnect(&self, id: &str) -> Result<(), String> {
-        crate::commands::logs::log_dev(format!(
-            "[dev][ssh_pool] disconnect begin id={id}"
-        ));
+        crate::commands::logs::log_dev(format!("[dev][ssh_pool] disconnect begin id={id}"));
         if let Some(host) = self.connections.lock().await.remove(id) {
             let session = host.session.lock().await.clone();
             session.close().await;
             crate::commands::logs::log_dev(format!(
                 "[dev][ssh_pool] disconnect removed id={} home={}",
-                id,
-                host.home_dir
+                id, host.home_dir
             ));
         } else {
             let known = {
@@ -149,15 +144,13 @@ impl SshConnectionPool {
     pub async fn reconnect(&self, id: &str) -> Result<(), String> {
         let (config, passphrase) = {
             let guard = self.connections.lock().await;
-            let host = guard
-                .get(id)
-                .ok_or_else(|| {
-                    crate::commands::logs::log_dev(format!(
-                        "[dev][ssh_pool] reconnect missing connection id={id} known={}",
-                        Self::format_connection_ids(&guard)
-                    ));
-                    format!("No connection for id: {id}")
-                })?;
+            let host = guard.get(id).ok_or_else(|| {
+                crate::commands::logs::log_dev(format!(
+                    "[dev][ssh_pool] reconnect missing connection id={id} known={}",
+                    Self::format_connection_ids(&guard)
+                ));
+                format!("No connection for id: {id}")
+            })?;
             crate::commands::logs::log_dev(format!(
                 "[dev][ssh_pool] reconnect begin id={} passphrase_present={}",
                 id,
@@ -165,17 +158,17 @@ impl SshConnectionPool {
             ));
             (host.config.clone(), host.passphrase.clone())
         };
-        if let Err(error) = self.connect_with_passphrase(&config, passphrase.as_deref()).await {
+        if let Err(error) = self
+            .connect_with_passphrase(&config, passphrase.as_deref())
+            .await
+        {
             crate::commands::logs::log_dev(format!(
                 "[dev][ssh_pool] reconnect failed id={} error={}",
-                id,
-                error
+                id, error
             ));
             return Err(format!("ssh reconnect failed: {error}"));
         }
-        crate::commands::logs::log_dev(format!(
-            "[dev][ssh_pool] reconnect success id={id}"
-        ));
+        crate::commands::logs::log_dev(format!("[dev][ssh_pool] reconnect success id={id}"));
         Ok(())
     }
 
@@ -189,15 +182,13 @@ impl SshConnectionPool {
 
     pub async fn get_home_dir(&self, id: &str) -> Result<String, String> {
         let guard = self.connections.lock().await;
-        let conn = guard
-            .get(id)
-            .ok_or_else(|| {
-                crate::commands::logs::log_dev(format!(
-                    "[dev][ssh_pool] get_home_dir missing connection id={id} known={}",
-                    Self::format_connection_ids(&guard)
-                ));
-                format!("No connection for id: {id}")
-            })?;
+        let conn = guard.get(id).ok_or_else(|| {
+            crate::commands::logs::log_dev(format!(
+                "[dev][ssh_pool] get_home_dir missing connection id={id} known={}",
+                Self::format_connection_ids(&guard)
+            ));
+            format!("No connection for id: {id}")
+        })?;
         crate::commands::logs::log_dev(format!(
             "[dev][ssh_pool] get_home_dir found id={id} home={}",
             conn.home_dir
@@ -218,23 +209,16 @@ impl SshConnectionPool {
         let conn = self.lookup_connected_host(id).await?;
         crate::commands::logs::log_dev(format!(
             "[dev][ssh_pool] exec start id={} command={}",
-            id,
-            command
+            id, command
         ));
-        let _permit = conn
-            .op_limiter
-            .clone()
-            .acquire_owned()
-            .await
-            .map_err(|e| {
-                let message = format!("ssh limiter acquire failed: {e}");
-                crate::commands::logs::log_dev(format!(
-                    "[dev][ssh_pool] exec acquire semaphore failed id={} error={}",
-                    id,
-                    message
-                ));
-                message
-            })?;
+        let _permit = conn.op_limiter.clone().acquire_owned().await.map_err(|e| {
+            let message = format!("ssh limiter acquire failed: {e}");
+            crate::commands::logs::log_dev(format!(
+                "[dev][ssh_pool] exec acquire semaphore failed id={} error={}",
+                id, message
+            ));
+            message
+        })?;
         let mut result = {
             let session = conn.session.lock().await.clone();
             session.exec(command).await
@@ -242,8 +226,7 @@ impl SshConnectionPool {
         if let Err(err) = &result {
             crate::commands::logs::log_dev(format!(
                 "[dev][ssh_pool] exec got session error id={} error={}",
-                id,
-                err
+                id, err
             ));
             if is_retryable_session_error(&err.to_string()) {
                 self.refresh_session(&conn).await?;
@@ -255,8 +238,7 @@ impl SshConnectionPool {
             let message = e.to_string();
             crate::commands::logs::log_dev(format!(
                 "[dev][ssh_pool] exec failed id={} error={}",
-                id,
-                message
+                id, message
             ));
             message
         })?;
@@ -283,23 +265,16 @@ impl SshConnectionPool {
         let conn = self.lookup_connected_host(id).await?;
         crate::commands::logs::log_dev(format!(
             "[dev][ssh_pool] sftp_read start id={} path={}",
-            id,
-            resolved
+            id, resolved
         ));
-        let _permit = conn
-            .op_limiter
-            .clone()
-            .acquire_owned()
-            .await
-            .map_err(|e| {
-                let message = format!("ssh limiter acquire failed: {e}");
-                crate::commands::logs::log_dev(format!(
-                    "[dev][ssh_pool] sftp_read acquire semaphore failed id={} error={}",
-                    id,
-                    message
-                ));
-                message
-            })?;
+        let _permit = conn.op_limiter.clone().acquire_owned().await.map_err(|e| {
+            let message = format!("ssh limiter acquire failed: {e}");
+            crate::commands::logs::log_dev(format!(
+                "[dev][ssh_pool] sftp_read acquire semaphore failed id={} error={}",
+                id, message
+            ));
+            message
+        })?;
         let mut bytes = {
             let session = conn.session.lock().await.clone();
             session.sftp_read(&resolved).await
@@ -307,9 +282,7 @@ impl SshConnectionPool {
         if let Err(err) = &bytes {
             crate::commands::logs::log_dev(format!(
                 "[dev][ssh_pool] sftp_read primary error id={} path={} error={}",
-                id,
-                resolved,
-                err
+                id, resolved, err
             ));
             if is_retryable_session_error(&err.to_string()) {
                 self.refresh_session(&conn).await?;
@@ -324,9 +297,7 @@ impl SshConnectionPool {
                 if !should_attempt_sftp_exec_fallback(&primary_msg) {
                     crate::commands::logs::log_dev(format!(
                         "[dev][ssh_pool] sftp_read failed without fallback id={} path={} error={}",
-                        id,
-                        resolved,
-                        primary_msg
+                        id, resolved, primary_msg
                     ));
                     return Err(primary_msg);
                 }
@@ -335,9 +306,7 @@ impl SshConnectionPool {
                     Err(fallback_err) => {
                         crate::commands::logs::log_dev(format!(
                             "[dev][ssh_pool] sftp_read fallback failed id={} path={} error={}",
-                            id,
-                            resolved,
-                            fallback_err
+                            id, resolved, fallback_err
                         ));
                         return Err(format!(
                             "{primary_msg}; fallback via ssh cat failed: {fallback_err}"
@@ -359,24 +328,17 @@ impl SshConnectionPool {
         let resolved = self.resolve_path(id, path).await?;
         crate::commands::logs::log_dev(format!(
             "[dev][ssh_pool] sftp_write start id={} path={}",
-            id,
-            resolved
+            id, resolved
         ));
         let conn = self.lookup_connected_host(id).await?;
-        let _permit = conn
-            .op_limiter
-            .clone()
-            .acquire_owned()
-            .await
-            .map_err(|e| {
-                let message = format!("ssh limiter acquire failed: {e}");
-                crate::commands::logs::log_dev(format!(
-                    "[dev][ssh_pool] sftp_write acquire semaphore failed id={} error={}",
-                    id,
-                    message
-                ));
-                message
-            })?;
+        let _permit = conn.op_limiter.clone().acquire_owned().await.map_err(|e| {
+            let message = format!("ssh limiter acquire failed: {e}");
+            crate::commands::logs::log_dev(format!(
+                "[dev][ssh_pool] sftp_write acquire semaphore failed id={} error={}",
+                id, message
+            ));
+            message
+        })?;
         let mut write_res = {
             let session = conn.session.lock().await.clone();
             session.sftp_write(&resolved, content.as_bytes()).await
@@ -384,9 +346,7 @@ impl SshConnectionPool {
         if let Err(err) = &write_res {
             crate::commands::logs::log_dev(format!(
                 "[dev][ssh_pool] sftp_write primary error id={} path={} error={}",
-                id,
-                resolved,
-                err
+                id, resolved, err
             ));
             if is_retryable_session_error(&err.to_string()) {
                 self.refresh_session(&conn).await?;
@@ -398,16 +358,13 @@ impl SshConnectionPool {
             let message = e.to_string();
             crate::commands::logs::log_dev(format!(
                 "[dev][ssh_pool] sftp_write failed id={} path={} error={}",
-                id,
-                resolved,
-                message
+                id, resolved, message
             ));
             message
         })?;
         crate::commands::logs::log_dev(format!(
             "[dev][ssh_pool] sftp_write success id={} path={}",
-            id,
-            resolved
+            id, resolved
         ));
         Ok(())
     }
@@ -444,44 +401,37 @@ impl SshConnectionPool {
         let resolved = self.resolve_path(id, path).await?;
         crate::commands::logs::log_dev(format!(
             "[dev][ssh_pool] sftp_remove start id={} path={}",
-            id,
-            resolved
+            id, resolved
         ));
         let cmd = format!("rm -f {}", shell_quote(&resolved));
         let exec_result = self.exec(id, &cmd).await;
         if let Err(error) = exec_result {
             crate::commands::logs::log_dev(format!(
                 "[dev][ssh_pool] sftp_remove exec failed id={} path={} error={}",
-                id,
-                resolved,
-                error
+                id, resolved, error
             ));
             return Err(error);
         }
         crate::commands::logs::log_dev(format!(
             "[dev][ssh_pool] sftp_remove success id={} path={}",
-            id,
-            resolved
+            id, resolved
         ));
         Ok(())
     }
 
     async fn lookup_connected_host(&self, id: &str) -> Result<ConnectedHost, String> {
         let guard = self.connections.lock().await;
-        let conn = guard
-            .get(id)
-            .ok_or_else(|| {
-                crate::commands::logs::log_dev(format!(
-                    "[dev][ssh_pool] lookup_connected_host missing id={} known={}",
-                    id,
-                    Self::format_connection_ids(&guard)
-                ));
-                format!("No connection for id: {id}")
-            })?;
+        let conn = guard.get(id).ok_or_else(|| {
+            crate::commands::logs::log_dev(format!(
+                "[dev][ssh_pool] lookup_connected_host missing id={} known={}",
+                id,
+                Self::format_connection_ids(&guard)
+            ));
+            format!("No connection for id: {id}")
+        })?;
         crate::commands::logs::log_dev(format!(
             "[dev][ssh_pool] lookup_connected_host found id={} host={}",
-            id,
-            conn.config.host
+            id, conn.config.host
         ));
         Ok(conn.clone())
     }
@@ -501,8 +451,7 @@ impl SshConnectionPool {
                 let message = error.to_string();
                 crate::commands::logs::log_dev(format!(
                     "[dev][ssh_pool] refresh_session connect failed id={} error={}",
-                    conn.config.id,
-                    message
+                    conn.config.id, message
                 ));
                 message
             })?,
@@ -524,8 +473,7 @@ impl SshConnectionPool {
     ) -> Result<Vec<u8>, String> {
         crate::commands::logs::log_dev(format!(
             "[dev][ssh_pool] exec_cat_read_with_retry start id={} path={}",
-            conn.config.id,
-            path
+            conn.config.id, path
         ));
         let mut out = {
             let session = conn.session.lock().await.clone();
@@ -535,9 +483,7 @@ impl SshConnectionPool {
         if let Err(err) = &out {
             crate::commands::logs::log_dev(format!(
                 "[dev][ssh_pool] exec_cat_read_with_retry primary error id={} path={} error={}",
-                conn.config.id,
-                path,
-                err
+                conn.config.id, path, err
             ));
             if is_retryable_session_error(&err.to_string()) {
                 self.refresh_session(conn).await?;
@@ -550,9 +496,7 @@ impl SshConnectionPool {
             let message = error.to_string();
             crate::commands::logs::log_dev(format!(
                 "[dev][ssh_pool] exec_cat_read_with_retry failed id={} path={} error={}",
-                conn.config.id,
-                path,
-                message
+                conn.config.id, path, message
             ));
             message
         })?;

--- a/src/lib/__tests__/sshConnectErrors.test.ts
+++ b/src/lib/__tests__/sshConnectErrors.test.ts
@@ -9,14 +9,14 @@ import {
   buildSshPassphraseConnectErrorMessage,
 } from "../sshConnectErrors";
 
-const t = (key: string, opts: Record<string, string> = {}) => {
+const t = (key: string, opts: Record<string, string | number | boolean> = {}) => {
   const text = {
     "ssh.passphraseValidationFailed": "PASS_FAIL_{{host}}",
     "ssh.missingKeyFile": "MISSING_KEY_{{host}}",
     "ssh.publicKeyRejected": "PUBLIC_KEY_REJECTED_{{host}}",
     "ssh.passphraseCancelled": "CANCEL_{{host}}",
   }[key] || key;
-  return text.replace("{{host}}", opts.host ?? "");
+  return text.replace("{{host}}", String(opts.host ?? ""));
 };
 
 describe("sshConnectErrors", () => {

--- a/src/types/bun-test.d.ts
+++ b/src/types/bun-test.d.ts
@@ -1,0 +1,5 @@
+declare module "bun:test" {
+  export const describe: (name: string, fn: () => void | Promise<void>) => void;
+  export const test: (name: string, fn: () => void | Promise<void>) => void;
+  export const expect: (...args: any[]) => any;
+}


### PR DESCRIPTION
Closes #24

## Summary
- Add GitHub Actions CI workflow at `.github/workflows/ci.yml`.
- Run on push to `main` and `develop`, and on pull requests.
- Frontend job: `bun install --frozen-lockfile`, `bun run typecheck`, `bun run build`.
- Rust job (`working-directory: src-tauri`): install required system deps, `cargo fmt --all -- --check`, `cargo clippy --workspace -- -D warnings`, `cargo test --workspace`.
- Add concurrency with `cancel-in-progress: true`.
- Add `Swatinem/rust-cache`, `oven-sh/setup-bun`, and `dtolnay/rust-toolchain@stable` with `rustfmt, clippy`.
