### PR TITLE
fix: show hint when zeroclaw has no model profiles in fresh state

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1598,6 +1598,7 @@ export function App() {
               onDataChange={bumpConfigVersion}
               hasAppUpdate={appUpdateAvailable}
               onAppUpdateSeen={() => setAppUpdateAvailable(false)}
+              onNavigateToProfiles={() => setStartSection("profiles")}
             />
           )}
 

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -239,6 +239,7 @@
   "settings.zeroclawModelSaved": "Crayfish model preference saved",
   "settings.zeroclawModelSaveFailed": "Failed to save crayfish model preference: {{error}}",
   "settings.zeroclawNoProfiles": "No compatible model profiles found. Add a model profile in the Profiles section to enable Zeroclaw.",
+  "settings.zeroclawNoProfilesLink": "No compatible model profiles found. Go to Profiles to add one →",
   "settings.zeroclawUsageLoading": "Usage stats loading...",
   "settings.zeroclawUsageTotalTokens": "Token usage: {{count}}",
   "settings.zeroclawUsageCalls": "Calls: {{count}}",

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -239,6 +239,7 @@
   "settings.zeroclawModelSaved": "小龙虾模型偏好已保存",
   "settings.zeroclawModelSaveFailed": "保存小龙虾模型偏好失败：{{error}}",
   "settings.zeroclawNoProfiles": "未找到兼容的模型配置。请先在「配置」中添加模型，以启用 Zeroclaw。",
+  "settings.zeroclawNoProfilesLink": "未找到兼容的模型配置，前往「配置」添加 →",
   "settings.zeroclawUsageLoading": "用量统计加载中...",
   "settings.zeroclawUsageTotalTokens": "Token 用量：{{count}}",
   "settings.zeroclawUsageCalls": "调用次数：{{count}}",

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -172,6 +172,7 @@ export function Settings({
   globalMode = false,
   section = "all",
   onOpenDoctor,
+  onNavigateToProfiles,
 }: {
   onDataChange?: () => void;
   hasAppUpdate?: boolean;
@@ -179,6 +180,7 @@ export function Settings({
   globalMode?: boolean;
   section?: "all" | "profiles" | "preferences";
   onOpenDoctor?: () => void;
+  onNavigateToProfiles?: () => void;
 }) {
   const { t, i18n } = useTranslation();
   const ua = useApi();
@@ -758,7 +760,17 @@ export function Settings({
                   )}
                   {zeroclawModelCandidates.length === 0 && !zeroclawSaving && (
                     <p className="text-xs text-muted-foreground basis-full mt-1">
-                      {t("settings.zeroclawNoProfiles")}
+                      {onNavigateToProfiles ? (
+                        <button
+                          type="button"
+                          className="underline hover:text-foreground transition-colors"
+                          onClick={onNavigateToProfiles}
+                        >
+                          {t("settings.zeroclawNoProfilesLink")}
+                        </button>
+                      ) : (
+                        t("settings.zeroclawNoProfiles")
+                      )}
                     </p>
                   )}
                   <div className="ml-auto text-right text-xs text-muted-foreground min-w-[240px]">


### PR DESCRIPTION
## Problem

In a completely fresh state (no model profiles configured), the zeroclaw model preference selector in Settings → Preferences has an empty dropdown — only "Not set" with zero model candidates. Users cannot configure zeroclaw and it's effectively unusable.

## Fix

When `zeroclawModelCandidates` is empty, show an inline hint below the selector directing users to add a model profile in the Profiles section first.

Added i18n strings for both English and Chinese.

## Changes

- `src/pages/Settings.tsx` — conditional hint when no candidates
- `src/locales/en.json` / `zh.json` — new translation key `settings.zeroclawNoProfiles`

Closes #36