### PR TITLE
feat: add proactive SSH passphrase input field

### DIFF
--- a/clawpal-cli/src/main.rs
+++ b/clawpal-cli/src/main.rs
@@ -386,6 +386,7 @@ fn run_connect_command(command: ConnectCommands) -> Result<serde_json::Value, St
                 auth_method: "key".to_string(),
                 key_path,
                 password: None,
+                passphrase: None,
             };
             runtime
                 .block_on(connect_ssh(config))
@@ -460,7 +461,7 @@ enum DoctorTarget {
     Local,
     Remote {
         id: String,
-        host: clawpal_core::instance::SshHostConfig,
+        host: Box<clawpal_core::instance::SshHostConfig>,
     },
 }
 
@@ -481,7 +482,7 @@ fn resolve_doctor_target(instance: Option<String>) -> Result<DoctorTarget, Strin
         .ok_or_else(|| format!("instance '{instance_id}' is not an SSH instance"))?;
     Ok(DoctorTarget::Remote {
         id: instance_id,
-        host,
+        host: Box::new(host),
     })
 }
 

--- a/clawpal-core/src/connect.rs
+++ b/clawpal-core/src/connect.rs
@@ -172,6 +172,7 @@ mod tests {
             auth_method: "key".to_string(),
             key_path: None,
             password: None,
+            passphrase: None,
         };
         let result = connect_ssh(config).await;
         assert!(result.is_err());

--- a/clawpal-core/src/health.rs
+++ b/clawpal-core/src/health.rs
@@ -313,6 +313,7 @@ mod tests {
                 auth_method: "key".to_string(),
                 key_path: None,
                 password: None,
+                passphrase: None,
             }),
         };
         let status = check_instance(&instance).expect("remote health");

--- a/clawpal-core/src/instance.rs
+++ b/clawpal-core/src/instance.rs
@@ -16,6 +16,8 @@ pub struct SshHostConfig {
     pub auth_method: String,
     pub key_path: Option<String>,
     pub password: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub passphrase: Option<String>,
 }
 
 impl SshHostConfig {
@@ -416,6 +418,7 @@ mod tests {
                 auth_method: "key".to_string(),
                 key_path: None,
                 password: None,
+                passphrase: None,
             }),
         }
     }

--- a/clawpal-core/src/ssh/mod.rs
+++ b/clawpal-core/src/ssh/mod.rs
@@ -623,6 +623,7 @@ mod tests {
             auth_method: "key".to_string(),
             key_path: None,
             password: None,
+            passphrase: None,
         };
         let result = SshSession::connect(&cfg).await;
         assert!(result.is_err());
@@ -639,6 +640,7 @@ mod tests {
             auth_method: "password".to_string(),
             key_path: None,
             password: None,
+            passphrase: None,
         };
         let result = SshSession::connect(&cfg).await;
         assert!(result.is_err());
@@ -659,6 +661,7 @@ mod tests {
             auth_method: "key".to_string(),
             key_path: Some("~/.ssh/id_test".to_string()),
             password: None,
+            passphrase: None,
         };
         let resolved = resolve_target(&cfg).expect("resolve");
         assert_eq!(resolved.host, "example.com");
@@ -678,6 +681,7 @@ mod tests {
             auth_method: "key".to_string(),
             key_path: None,
             password: None,
+            passphrase: None,
         };
         let session = SshSession {
             config: cfg,

--- a/clawpal-core/src/ssh/registry.rs
+++ b/clawpal-core/src/ssh/registry.rs
@@ -130,6 +130,7 @@ mod tests {
             auth_method: "key".to_string(),
             key_path: Some("~/.ssh/id_ed25519".to_string()),
             password: None,
+            passphrase: None,
         }
     }
 

--- a/clawpal-core/tests/workflow_integration.rs
+++ b/clawpal-core/tests/workflow_integration.rs
@@ -93,6 +93,7 @@ fn ssh_registry_roundtrip_via_instance_registry() {
         auth_method: "key".to_string(),
         key_path: None,
         password: None,
+        passphrase: None,
     };
 
     ssh_registry::upsert_ssh_host(host.clone()).expect("upsert ssh host");
@@ -160,6 +161,7 @@ async fn connect_ssh_registers_remote_instance_with_fake_ssh() {
         auth_method: "key".to_string(),
         key_path: None,
         password: None,
+        passphrase: None,
     };
     let result = connect_ssh(cfg).await.expect("connect ssh");
     assert!(matches!(result.instance_type, InstanceType::RemoteSsh));
@@ -197,6 +199,7 @@ async fn connect_ssh_returns_error_when_exec_fails() {
         auth_method: "key".to_string(),
         key_path: None,
         password: None,
+        passphrase: None,
     };
     let result = connect_ssh(cfg).await;
     assert!(result.is_err());

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -5648,6 +5648,7 @@ pub fn migrate_legacy_instances(
                         auth_method: "ssh_config".to_string(),
                         key_path: None,
                         password: None,
+                        passphrase: None,
                     }),
                 },
             )?;
@@ -5738,7 +5739,20 @@ pub async fn ssh_connect(
         ));
         format!("No SSH host config with id: {host_id}")
     })?;
-    if let Err(error) = pool.connect(&host).await {
+    // If the host has a stored passphrase, use it directly
+    let connect_result = if let Some(ref pp) = host.passphrase {
+        if !pp.is_empty() {
+            crate::commands::logs::log_dev(format!(
+                "[dev][ssh_connect] using stored passphrase for host_id={host_id}"
+            ));
+            pool.connect_with_passphrase(&host, Some(pp.as_str())).await
+        } else {
+            pool.connect(&host).await
+        }
+    } else {
+        pool.connect(&host).await
+    };
+    if let Err(error) = connect_result {
         crate::commands::logs::log_dev(format!(
             "[dev][ssh_connect] failed host_id={} host={} user={} port={} auth_method={} error={}",
             host_id, host.host, host.username, host.port, host.auth_method, error

--- a/src-tauri/src/doctor_commands.rs
+++ b/src-tauri/src/doctor_commands.rs
@@ -1622,6 +1622,7 @@ async fn run_clawpal_tool(
                 auth_method: "key".to_string(),
                 key_path,
                 password: None,
+                passphrase: None,
             };
             let instance = clawpal_core::connect::connect_ssh(config)
                 .await

--- a/src-tauri/tests/commands_delegation.rs
+++ b/src-tauri/tests/commands_delegation.rs
@@ -28,6 +28,7 @@ fn ssh_host_crud_commands_delegate_to_core_registry() {
         auth_method: "key".to_string(),
         key_path: None,
         password: None,
+        passphrase: None,
     };
 
     let saved = upsert_ssh_host(host.clone()).expect("upsert should succeed");

--- a/src-tauri/tests/remote_api.rs
+++ b/src-tauri/tests/remote_api.rs
@@ -18,6 +18,7 @@ fn vm1_config() -> SshHostConfig {
         auth_method: "ssh_config".into(),
         key_path: None,
         password: None,
+        passphrase: None,
     }
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -776,6 +776,20 @@ export function App() {
       // and state hasn't refreshed), assume non-password auth so the passphrase
       // dialog is still shown instead of falling through to a misleading error.
       if ((!host || host.authMethod !== "password") && SSH_PASSPHRASE_RETRY_HINT.test(raw)) {
+        // If the host already had a stored passphrase, the backend already tried it.
+        // Skip the dialog — the stored passphrase was wrong.
+        if (host?.passphrase && host.passphrase.length > 0) {
+          const fallbackMessage = buildSshPassphraseConnectErrorMessage(raw, hostLabel, t);
+          if (fallbackMessage) {
+            throw new Error(fallbackMessage);
+          }
+          throw await explainAndBuildGuidanceError({
+            method: "sshConnect",
+            instanceId: hostId,
+            transport: "remote_ssh",
+            rawError: err,
+          });
+        }
         const passphrase = await requestPassphrase(hostLabel);
         if (passphrase !== null) {
           try {

--- a/src/components/SshFormWidget.tsx
+++ b/src/components/SshFormWidget.tsx
@@ -37,6 +37,7 @@ export function SshFormWidget({
   );
   const [keyPath, setKeyPath] = useState(defaults?.keyPath ?? "");
   const [password, setPassword] = useState(defaults?.password ?? "");
+  const [passphrase, setPassphrase] = useState(defaults?.passphrase ?? "");
   const [label, setLabel] = useState(defaults?.label ?? "");
   const [selectedSshConfigAlias, setSelectedSshConfigAlias] = useState(
     SSH_CONFIG_MANUAL_ALIAS,
@@ -71,6 +72,7 @@ export function SshFormWidget({
     setPort(String(preset.port ?? 22));
     setKeyPath(preset.identityFile ?? "");
     setPassword("");
+    setPassphrase("");
     setAuthMethod("ssh_config");
     setLabel(preset.hostAlias);
   };
@@ -88,6 +90,7 @@ export function SshFormWidget({
       authMethod,
       keyPath: authMethod === "key" ? keyPath.trim() : undefined,
       password: authMethod === "password" ? password : undefined,
+      passphrase: authMethod !== "password" && passphrase ? passphrase : undefined,
     });
   };
 
@@ -185,6 +188,18 @@ export function SshFormWidget({
             value={password}
             onChange={(e) => setPassword(e.target.value)}
             placeholder="••••••••"
+            className="h-8 text-sm"
+          />
+        </div>
+      )}
+      {authMethod !== "password" && (
+        <div className="space-y-1">
+          <label className="text-xs font-medium">{t("installChat.sshPassphrase")}</label>
+          <Input
+            type="password"
+            value={passphrase}
+            onChange={(e) => setPassphrase(e.target.value)}
+            placeholder={t("installChat.sshPassphrasePlaceholder")}
             className="h-8 text-sm"
           />
         </div>

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -298,6 +298,7 @@ export interface SshHost {
   authMethod: "key" | "ssh_config" | "password";
   keyPath?: string;
   password?: string;
+  passphrase?: string;
 }
 
 export interface SshConfigHostSuggestion {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -80,6 +80,8 @@
   "installChat.sshAuthPassword": "Password",
   "installChat.sshKeyPath": "Key Path",
   "installChat.sshPassword": "Password",
+  "installChat.sshPassphrase": "Key Passphrase",
+  "installChat.sshPassphrasePlaceholder": "Leave empty if key is not encrypted",
   "installChat.sshLabel": "Label",
   "installChat.submit": "Submit",
   "installChat.cancel": "Cancel",

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -80,6 +80,8 @@
   "installChat.sshAuthPassword": "密码",
   "installChat.sshKeyPath": "密钥路径",
   "installChat.sshPassword": "密码",
+  "installChat.sshPassphrase": "私钥口令",
+  "installChat.sshPassphrasePlaceholder": "若密钥未加密可留空",
   "installChat.sshLabel": "标签",
   "installChat.submit": "提交",
   "installChat.cancel": "取消",


### PR DESCRIPTION
## Summary

When SSH requires a passphrase for an encrypted private key, users previously had to wait for the connection to fail before being prompted. This PR adds an upfront passphrase input field in the SSH form.

## Changes

### Backend (Rust)
- Added `passphrase: Option<String>` to `SshHostConfig` with `#[serde(default, skip_serializing_if)]` for backward compatibility
- Modified `ssh_connect` command: if the host has a stored passphrase, it's used directly via `connect_with_passphrase()` — no fail-retry loop
- Boxed `DoctorTarget::Remote` host field to satisfy `clippy::large_enum_variant` after struct size increase

### Frontend (TypeScript/React)
- Added `passphrase?: string` to `SshHost` interface
- Added passphrase input field in `SshFormWidget` (visible for `key` and `ssh_config` auth methods)
- Updated `connectWithPassphraseFallback` in `App.tsx`: if the host already has a stored passphrase and connection fails, skip the passphrase dialog (the stored one was wrong) and show the error directly

### i18n
- Added `installChat.sshPassphrase` and `installChat.sshPassphrasePlaceholder` for en/zh

## Testing
- `cargo fmt --all` ✅
- `cargo clippy -p clawpal-core -p clawpal-cli -- -D warnings` ✅
- `cargo test -p clawpal-core` — 132/133 passed (1 pre-existing flaky ETXTBSY)

Closes: requested by @Keith-CY