### PR TITLE
feat: add PR build workflow with artifact download links

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   contents: read
+  issues: write
   pull-requests: write
   actions: read
 
@@ -132,6 +133,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Post or update PR comment with download links
+        continue-on-error: true
         uses: actions/github-script@v7
         with:
           script: |


### PR DESCRIPTION
## Summary

Add a GitHub Actions workflow that automatically builds ClawPal for all platforms on every PR and posts download links as a PR comment.

## What it does

1. **Triggers** on every PR to `develop` or `main`
2. **Builds** Tauri app for 4 targets:
   - macOS ARM64 (Apple Silicon)
   - macOS x64 (Intel)
   - Linux x64
   - Windows x64 (+ portable exe)
3. **Uploads** build artifacts (7-day retention)
4. **Posts a PR comment** with a download table:

   | Platform | Download | Size |
   |----------|----------|------|
   | macOS-ARM64 | 📥 clawpal-macOS-ARM64 | 12.3 MB |
   | Linux-x64 | 📥 clawpal-Linux-x64 | 8.1 MB |
   | ... | ... | ... |

5. **Edits the same comment** when new commits are pushed (no duplicate comments)

## Design decisions

- **Unsigned builds**: Code signing and updater artifacts are disabled for PR builds (ad-hoc signing on macOS via `signingIdentity: "-"`)
- **Concurrency**: Cancels in-progress builds when new commits are pushed to the same PR
- **Idempotent comments**: Uses an HTML marker (`<!-- pr-build-artifacts -->`) to find and update the existing comment
- **Partial failure tolerant**: Comment job runs even if some platform builds fail (`if: always()`)
