### PR TITLE
fix: improve log button visibility and add log export

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -323,6 +323,7 @@
   "doctor.errorLog": "Error Log",
   "doctor.noLogs": "No log entries yet.",
   "doctor.refreshLogs": "Refresh",
+  "doctor.exportLogs": "Export",
   "doctor.agentSource": "Doctor Claw Assistant",
   "doctor.engineZeroclaw": "Doctor Claw",
   "doctor.sshRemote": "SSH Remote",

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -323,6 +323,7 @@
   "doctor.errorLog": "错误日志",
   "doctor.noLogs": "暂无日志记录。",
   "doctor.refreshLogs": "刷新",
+  "doctor.exportLogs": "导出",
   "doctor.agentSource": "Doctor Claw 诊断助手",
   "doctor.engineZeroclaw": "Doctor Claw",
   "doctor.sshRemote": "SSH 远程",

--- a/src/pages/Doctor.tsx
+++ b/src/pages/Doctor.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { useTranslation } from "react-i18next";
+import { FileTextIcon, DownloadIcon } from "lucide-react";
 import { useApi, hasGuidanceEmitted } from "@/lib/use-api";
 import { useInstance } from "@/lib/instance-context";
 import { useDoctorAgent } from "@/lib/use-doctor-agent";
@@ -318,6 +319,21 @@ export function Doctor({
     setLogsSource(source);
     setLogsTab("app");
     setLogsOpen(true);
+  };
+
+  const exportLogs = () => {
+    if (!logsContent) return;
+    const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+    const filename = `${logsSource}-${logsTab}-${timestamp}.log`;
+    const blob = new Blob([logsContent], { type: "text/plain" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = filename;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
   };
 
   const refreshRescueStatus = async (isCancelled?: () => boolean) => {
@@ -998,10 +1014,12 @@ export function Doctor({
                   {t("doctor.targetExecutionLocalWarning")}
                 </span>
               )}
-              <Button variant="ghost" size="sm" onClick={() => openLogs("clawpal")}>
+              <Button variant="outline" size="sm" onClick={() => openLogs("clawpal")}>
+                <FileTextIcon className="h-3.5 w-3.5 mr-1.5" />
                 {t("doctor.clawpalLogs")}
               </Button>
-              <Button variant="ghost" size="sm" onClick={() => openLogs("gateway")}>
+              <Button variant="outline" size="sm" onClick={() => openLogs("gateway")}>
+                <FileTextIcon className="h-3.5 w-3.5 mr-1.5" />
                 {t("doctor.gatewayLogs")}
               </Button>
             </div>
@@ -1156,6 +1174,15 @@ export function Doctor({
               disabled={logsLoading}
             >
               {t("doctor.refreshLogs")}
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={exportLogs}
+              disabled={!logsContent}
+            >
+              <DownloadIcon className="h-3.5 w-3.5 mr-1.5" />
+              {t("doctor.exportLogs")}
             </Button>
           </div>
           <pre


### PR DESCRIPTION
## Changes

### Problem
The **ClawPal Logs** and **Gateway Logs** buttons in the Doctor Claw Assistant header use `variant="ghost"`, making them look like plain text rather than clickable buttons.

Additionally, there's no way to export/download log content once viewed.

### Solution
1. **Button styling** — Changed from `ghost` to `outline` variant and added a `FileTextIcon` prefix, so they're clearly identifiable as interactive buttons.
2. **Log export** — Added an **Export** button (with `DownloadIcon`) in the log viewer dialog. Clicking it downloads the currently displayed log as a `.log` file (named like `clawpal-app-2026-03-03T04-05-00-000Z.log`).

### Files changed
- `src/pages/Doctor.tsx` — button variant + icon + export logic
- `src/locales/en.json` / `src/locales/zh.json` — added `doctor.exportLogs` key

Closes no issue (requested by Chen Yu in Discord).