### PR TITLE
fix: add loading feedback and optimistic removal for backup deletion

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -51,6 +51,7 @@
   "home.active": "active",
   "home.idle": "idle",
   "home.delete": "Delete",
+  "home.deleting": "Deleting...",
   "home.deleteAgentTitle": "Delete agent \"{{agentId}}\"?",
   "home.deleteAgentDescription": "This will remove the agent from the config and any channel bindings associated with it.",
   "home.recommendedRecipes": "Recommended Recipes",

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -51,6 +51,7 @@
   "home.active": "活跃",
   "home.idle": "闲置",
   "home.delete": "删除",
+  "home.deleting": "删除中...",
   "home.deleteAgentTitle": "删除 Agent \"{{agentId}}\"？",
   "home.deleteAgentDescription": "这将从配置中移除该 Agent 及其关联的频道绑定。",
   "home.recommendedRecipes": "推荐菜谱",

--- a/src/pages/Doctor.tsx
+++ b/src/pages/Doctor.tsx
@@ -149,6 +149,7 @@ export function Doctor({
   const [backups, setBackups] = useState<BackupInfo[] | null>(null);
   const [backingUp, setBackingUp] = useState(false);
   const [backupMessage, setBackupMessage] = useState("");
+  const [deletingBackupName, setDeletingBackupName] = useState<string | null>(null);
 
   // Full-auto confirmation dialog
   const [fullAutoConfirmOpen, setFullAutoConfirmOpen] = useState(false);
@@ -1252,6 +1253,7 @@ export function Doctor({
                       <Button
                         size="sm"
                         variant="outline"
+                        disabled={deletingBackupName != null}
                         onClick={() => ua.openUrl(backup.path)}
                       >
                         {t("home.show")}
@@ -1259,7 +1261,7 @@ export function Doctor({
                     )}
                     <AlertDialog>
                       <AlertDialogTrigger asChild>
-                        <Button size="sm" variant="outline">
+                        <Button size="sm" variant="outline" disabled={deletingBackupName != null}>
                           {t("home.restore")}
                         </Button>
                       </AlertDialogTrigger>
@@ -1286,8 +1288,8 @@ export function Doctor({
                     </AlertDialog>
                     <AlertDialog>
                       <AlertDialogTrigger asChild>
-                        <Button size="sm" variant="destructive">
-                          {t("home.delete")}
+                        <Button size="sm" variant="destructive" disabled={deletingBackupName === backup.name}>
+                          {deletingBackupName === backup.name ? t("home.deleting") : t("home.delete")}
                         </Button>
                       </AlertDialogTrigger>
                       <AlertDialogContent>
@@ -1302,12 +1304,15 @@ export function Doctor({
                           <AlertDialogAction
                             className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
                             onClick={() => {
+                              setDeletingBackupName(backup.name);
                               ua.deleteBackup(backup.name)
                                 .then(() => {
+                                  setBackups((prev) => prev?.filter((b) => b.name !== backup.name) ?? null);
                                   setBackupMessage(t("home.deletedBackup", { name: backup.name }));
                                   refreshBackups();
                                 })
-                                .catch((e) => { if (!hasGuidanceEmitted(e)) setBackupMessage(t("home.deleteBackupFailed", { error: String(e) })); });
+                                .catch((e) => { if (!hasGuidanceEmitted(e)) setBackupMessage(t("home.deleteBackupFailed", { error: String(e) })); })
+                                .finally(() => setDeletingBackupName(null));
                             }}
                           >
                             {t("home.delete")}


### PR DESCRIPTION
## Summary

Fixes #52 — two UX issues when deleting a backup:

1. **No loading feedback** after confirming deletion — the dialog closes and nothing visually changes until the operation completes (especially slow on remote SSH instances)
2. **Deleted backup stays in list** — even after the success message appears, the backup card remains visible

## Changes

### `src/pages/Doctor.tsx`
- Add `deletingBackupName` state to track which backup is being deleted
- Show "Deleting..." text on the delete button while the operation is in progress
- Disable Show / Restore / Delete buttons during deletion to prevent concurrent operations
- **Optimistically remove** the backup from local state immediately on success (`setBackups(prev => prev?.filter(...))`), before `refreshBackups()` re-fetches from backend

### `src/locales/en.json` / `zh.json`
- Add `home.deleting` key: "Deleting..." / "删除中..."

## Testing
- Bun tests pass (69/69) ✅
- The fix is minimal and scoped to the backup section of Doctor.tsx