### PR TITLE
fix: resolve UI cache staleness causing conflicting/stale updates after mutations

### DIFF
--- a/src/lib/__tests__/use-api-cache.test.ts
+++ b/src/lib/__tests__/use-api-cache.test.ts
@@ -1,0 +1,74 @@
+import { describe, test, expect } from "bun:test";
+
+// Test the cache primitives directly (without React hooks)
+// These are the module-level functions that power the caching layer.
+
+// We need to import the internal cache functions.
+// Since they're module-scoped, we test via the exported API:
+import {
+  setOptimisticReadCache,
+  readCacheValue,
+  buildCacheKey,
+  invalidateGlobalReadCache,
+} from "../use-api";
+
+describe("buildCacheKey", () => {
+  test("builds key with method only", () => {
+    const key = buildCacheKey("inst#1", "listAgents");
+    expect(key).toBe("inst#1:listAgents:[]");
+  });
+
+  test("builds key with args", () => {
+    const key = buildCacheKey("inst#1", "getCronRuns", ["job-1", 10]);
+    expect(key).toBe('inst#1:getCronRuns:["job-1",10]');
+  });
+
+  test("different instances produce different keys", () => {
+    const a = buildCacheKey("inst#1", "listAgents");
+    const b = buildCacheKey("inst#2", "listAgents");
+    expect(a).not.toBe(b);
+  });
+});
+
+describe("setOptimisticReadCache", () => {
+  test("sets and reads a value", () => {
+    const key = buildCacheKey("test#optimistic", "myMethod");
+    setOptimisticReadCache(key, [{ id: "a" }, { id: "b" }]);
+    const result = readCacheValue(key);
+    expect(result).toEqual([{ id: "a" }, { id: "b" }]);
+  });
+
+  test("overwrites previous cache value", () => {
+    const key = buildCacheKey("test#overwrite", "data");
+    setOptimisticReadCache(key, "old");
+    setOptimisticReadCache(key, "new");
+    expect(readCacheValue(key)).toBe("new");
+  });
+
+  test("returns undefined for unknown keys", () => {
+    expect(readCacheValue("nonexistent:key:[]")).toBeUndefined();
+  });
+});
+
+describe("invalidateGlobalReadCache", () => {
+  test("clears global cache entries", () => {
+    const key = buildCacheKey("__global__", "listModelProfiles");
+    setOptimisticReadCache(key, [{ id: "p1" }]);
+    expect(readCacheValue(key)).toBeDefined();
+
+    invalidateGlobalReadCache(["listModelProfiles"]);
+    // After invalidation, the entry should be deleted
+    expect(readCacheValue(key)).toBeUndefined();
+  });
+
+  test("does not clear non-matching methods", () => {
+    const kept = buildCacheKey("__global__", "getAppPreferences");
+    const cleared = buildCacheKey("__global__", "listModelProfiles");
+    setOptimisticReadCache(kept, "keep-me");
+    setOptimisticReadCache(cleared, "clear-me");
+
+    invalidateGlobalReadCache(["listModelProfiles"]);
+    expect(readCacheValue(kept)).toBe("keep-me");
+    expect(readCacheValue(cleared)).toBeUndefined();
+  });
+});

--- a/src/lib/use-api.ts
+++ b/src/lib/use-api.ts
@@ -15,10 +15,47 @@ type ApiReadCacheEntry = {
   expiresAt: number;
   value: unknown;
   inFlight?: Promise<unknown>;
+  /** If > Date.now(), this entry is "pinned" by an optimistic update and polls should not overwrite it. */
+  optimisticUntil?: number;
 };
 
 const API_READ_CACHE = new Map<string, ApiReadCacheEntry>();
 const API_READ_CACHE_MAX_ENTRIES = 512;
+
+/** Subscribers keyed by cache key; notified on cache value changes. */
+const _cacheSubscribers = new Map<string, Set<() => void>>();
+
+function _notifyCacheSubscribers(key: string) {
+  const subs = _cacheSubscribers.get(key);
+  if (subs) {
+    for (const fn of subs) fn();
+  }
+}
+
+/** Subscribe to changes on a specific cache key. Returns an unsubscribe function. */
+export function subscribeToCacheKey(key: string, callback: () => void): () => void {
+  let set = _cacheSubscribers.get(key);
+  if (!set) {
+    set = new Set();
+    _cacheSubscribers.set(key, set);
+  }
+  set.add(callback);
+  return () => {
+    set!.delete(callback);
+    if (set!.size === 0) _cacheSubscribers.delete(key);
+  };
+}
+
+/** Read the current cached value for a key (if any). */
+export function readCacheValue<T>(key: string): T | undefined {
+  const entry = API_READ_CACHE.get(key);
+  return entry?.value as T | undefined;
+}
+
+export function buildCacheKey(instanceCacheKey: string, method: string, args: unknown[] = []): string {
+  return makeCacheKey(instanceCacheKey, method, args);
+}
+
 function makeCacheKey(instanceCacheKey: string, method: string, args: unknown[]): string {
   let serializedArgs = "";
   try {
@@ -46,17 +83,44 @@ function invalidateReadCacheForInstance(instanceCacheKey: string, methods?: stri
     if (!key.startsWith(`${instanceCacheKey}:`)) continue;
     if (!methodSet) {
       API_READ_CACHE.delete(key);
+      _notifyCacheSubscribers(key);
       continue;
     }
     const method = key.slice(instanceCacheKey.length + 1).split(":", 1)[0];
     if (methodSet.has(method)) {
       API_READ_CACHE.delete(key);
+      _notifyCacheSubscribers(key);
     }
   }
 }
 
 export function invalidateGlobalReadCache(methods?: string[]) {
   invalidateReadCacheForInstance("__global__", methods);
+}
+
+/**
+ * Set an optimistic value for a cache key, "pinning" it so that polling
+ * results will NOT overwrite it for `pinDurationMs` (default 15s).
+ *
+ * This solves the race condition where:
+ *   mutation → optimistic setState → poll fires → stale cache → UI flickers back
+ *
+ * The pin auto-expires, so if the backend takes longer than expected,
+ * the next poll after expiry will overwrite with fresh data.
+ */
+export function setOptimisticReadCache<T>(
+  key: string,
+  value: T,
+  pinDurationMs = 15_000,
+) {
+  const existing = API_READ_CACHE.get(key);
+  API_READ_CACHE.set(key, {
+    value,
+    expiresAt: Date.now() + pinDurationMs, // Keep it "valid" for the pin duration
+    optimisticUntil: Date.now() + pinDurationMs,
+    inFlight: existing?.inFlight,
+  });
+  _notifyCacheSubscribers(key);
 }
 
 function callWithReadCache<TResult>(
@@ -71,6 +135,10 @@ function callWithReadCache<TResult>(
   const key = makeCacheKey(instanceCacheKey, method, args);
   const entry = API_READ_CACHE.get(key);
   if (entry) {
+    // If pinned by optimistic update, return the pinned value
+    if (entry.optimisticUntil && entry.optimisticUntil > now) {
+      return Promise.resolve(entry.value as TResult);
+    }
     if (entry.expiresAt > now) {
       return Promise.resolve(entry.value as TResult);
     }
@@ -80,11 +148,23 @@ function callWithReadCache<TResult>(
   }
   const request = loader()
     .then((value) => {
+      const current = API_READ_CACHE.get(key);
+      // Don't overwrite if a newer optimistic value was set while we were fetching
+      if (current?.optimisticUntil && current.optimisticUntil > Date.now()) {
+        // Clear inFlight but keep the optimistic value
+        API_READ_CACHE.set(key, {
+          ...current,
+          inFlight: undefined,
+        });
+        return current.value as TResult;
+      }
       API_READ_CACHE.set(key, {
         value,
         expiresAt: Date.now() + ttlMs,
+        optimisticUntil: undefined,
       });
       trimReadCacheIfNeeded();
+      _notifyCacheSubscribers(key);
       return value;
     })
     .catch((error) => {
@@ -97,6 +177,7 @@ function callWithReadCache<TResult>(
   API_READ_CACHE.set(key, {
     value: entry?.value,
     expiresAt: entry?.expiresAt ?? 0,
+    optimisticUntil: entry?.optimisticUntil,
     inFlight: request as Promise<unknown>,
   });
   trimReadCacheIfNeeded();
@@ -305,11 +386,36 @@ export function useApi() {
     [instanceCacheKey, globalCacheKey],
   );
 
+  /**
+   * Pin an optimistic value in the read cache for a specific API method.
+   * While pinned (default 15s), polling calls to the same method will
+   * return the pinned value instead of overwriting with stale backend data.
+   *
+   * Usage: ua.pinOptimistic("listAgents", agents.filter(a => a.id !== deletedId));
+   */
+  const pinOptimistic = useCallback(
+    <T,>(method: string, value: T, args: unknown[] = [], pinDurationMs = 15_000) => {
+      const key = makeCacheKey(instanceCacheKey, method, args);
+      setOptimisticReadCache(key, value, pinDurationMs);
+    },
+    [instanceCacheKey],
+  );
+
+  /** Pin an optimistic value in the global cache (for methods like listModelProfiles). */
+  const pinOptimisticGlobal = useCallback(
+    <T,>(method: string, value: T, args: unknown[] = [], pinDurationMs = 15_000) => {
+      const key = makeCacheKey(globalCacheKey, method, args);
+      setOptimisticReadCache(key, value, pinDurationMs);
+    },
+    [globalCacheKey],
+  );
+
   return useMemo(
     () => ({
       // Instance state
       instanceId,
       instanceToken,
+      instanceCacheKey,
       isRemote,
       isDocker,
       isConnected,
@@ -319,6 +425,10 @@ export function useApi() {
       discordChannelsLoading,
       refreshChannelNodesCache,
       refreshDiscordChannelsCache,
+
+      // Optimistic cache pinning
+      pinOptimistic,
+      pinOptimisticGlobal,
 
       // Status
       getInstanceStatus: dispatch(
@@ -657,7 +767,10 @@ export function useApi() {
       localGlobalCached,
       withInvalidation,
       withGlobalInvalidation,
+      pinOptimistic,
+      pinOptimisticGlobal,
       instanceId,
+      instanceCacheKey,
       isRemote,
       isDocker,
       isConnected,

--- a/src/lib/use-cached-query.ts
+++ b/src/lib/use-cached-query.ts
@@ -1,0 +1,353 @@
+/**
+ * useCachedQuery — reactive cache-first data fetching with optimistic update support.
+ *
+ * Solves the dual-state race condition where:
+ *   - Component-level `useState` holds optimistic data
+ *   - Module-level `API_READ_CACHE` holds stale TTL data
+ *   - Polling overwrites optimistic state with stale cache
+ *
+ * This hook unifies cache + component state into a single reactive layer:
+ *   - Components subscribe to cache key changes
+ *   - `setOptimistic()` pins data in cache, preventing poll overwrite
+ *   - Mutations invalidate related keys and trigger immediate refetch
+ *   - Stale-while-revalidate: show cached data first, update when fresh arrives
+ */
+
+import { useCallback, useEffect, useRef, useState, useSyncExternalStore } from "react";
+
+// ─── Global reactive cache ───────────────────────────────────────────
+
+interface CacheEntry<T = unknown> {
+  value: T | undefined;
+  expiresAt: number;
+  generation: number;       // Incremented on every write (optimistic or fetch)
+  optimisticUntil: number;  // If > Date.now(), this entry is "pinned" (poll won't overwrite)
+  inFlight: Promise<T> | null;
+}
+
+type Subscriber = () => void;
+
+const _cache = new Map<string, CacheEntry>();
+const _subscribers = new Map<string, Set<Subscriber>>();
+let _globalGeneration = 0;
+
+function _notify(key: string) {
+  const subs = _subscribers.get(key);
+  if (subs) {
+    for (const fn of subs) fn();
+  }
+}
+
+function _subscribe(key: string, fn: Subscriber): () => void {
+  let set = _subscribers.get(key);
+  if (!set) {
+    set = new Set();
+    _subscribers.set(key, set);
+  }
+  set.add(fn);
+  return () => {
+    set!.delete(fn);
+    if (set!.size === 0) _subscribers.delete(key);
+  };
+}
+
+function _getEntry<T>(key: string): CacheEntry<T> | undefined {
+  return _cache.get(key) as CacheEntry<T> | undefined;
+}
+
+function _setEntry<T>(key: string, partial: Partial<CacheEntry<T>>) {
+  const existing = _cache.get(key) as CacheEntry<T> | undefined;
+  const entry: CacheEntry<T> = {
+    value: partial.value !== undefined ? partial.value : existing?.value,
+    expiresAt: partial.expiresAt ?? existing?.expiresAt ?? 0,
+    generation: partial.generation ?? (existing ? existing.generation + 1 : ++_globalGeneration),
+    optimisticUntil: partial.optimisticUntil ?? existing?.optimisticUntil ?? 0,
+    inFlight: partial.inFlight !== undefined ? partial.inFlight : existing?.inFlight ?? null,
+  };
+  _cache.set(key, entry as CacheEntry);
+  _notify(key);
+}
+
+// ─── Public cache API ────────────────────────────────────────────────
+
+/**
+ * Set an optimistic value for a cache key.
+ * This "pins" the value for `pinDurationMs` (default 10s), during which
+ * polling results will NOT overwrite it.
+ */
+export function setOptimisticCacheValue<T>(
+  key: string,
+  value: T,
+  pinDurationMs = 10_000,
+) {
+  _setEntry(key, {
+    value,
+    optimisticUntil: Date.now() + pinDurationMs,
+    generation: (_cache.get(key)?.generation ?? _globalGeneration) + 1,
+  });
+}
+
+/**
+ * Invalidate cache entries by key prefix and/or method names.
+ * Notifies all subscribers so they refetch.
+ */
+export function invalidateCacheKeys(prefix: string, methods?: string[]) {
+  const methodSet = methods ? new Set(methods) : null;
+  for (const key of _cache.keys()) {
+    if (!key.startsWith(prefix)) continue;
+    if (methodSet) {
+      // Key format: "prefix:method:args"
+      const rest = key.slice(prefix.length + 1);
+      const method = rest.split(":", 1)[0];
+      if (!methodSet.has(method)) continue;
+    }
+    const entry = _cache.get(key)!;
+    // Clear the entry but keep subscribers
+    _cache.set(key, {
+      ...entry,
+      expiresAt: 0,
+      optimisticUntil: 0,
+      inFlight: null,
+    });
+    _notify(key);
+  }
+}
+
+/**
+ * Invalidate + immediately refetch specific keys.
+ * Used after mutations to ensure fresh data replaces stale cache.
+ */
+export function invalidateAndRefetch(keys: string[]) {
+  for (const key of keys) {
+    const entry = _cache.get(key);
+    if (entry) {
+      _cache.set(key, {
+        ...entry,
+        expiresAt: 0,
+        optimisticUntil: 0,
+        inFlight: null,
+      });
+      _notify(key);
+    }
+  }
+}
+
+// ─── Trim ────────────────────────────────────────────────────────────
+
+const MAX_ENTRIES = 512;
+function _trimIfNeeded() {
+  if (_cache.size <= MAX_ENTRIES) return;
+  const deleteCount = _cache.size - MAX_ENTRIES;
+  const keys = _cache.keys();
+  for (let i = 0; i < deleteCount; i++) {
+    const next = keys.next();
+    if (next.done) break;
+    // Don't trim entries with active subscribers
+    if (_subscribers.has(next.value)) continue;
+    _cache.delete(next.value);
+  }
+}
+
+// ─── useCachedQuery hook ─────────────────────────────────────────────
+
+export interface UseCachedQueryOptions {
+  /** Polling interval in ms. 0 = no polling. */
+  pollInterval?: number;
+  /** Cache TTL in ms. Default 10_000. */
+  ttlMs?: number;
+  /** Whether to skip fetching (e.g., when preconditions not met). */
+  enabled?: boolean;
+  /** If true, skip poll when there are pending queued commands (for optimistic UI). */
+  skipWhenPending?: boolean;
+}
+
+export interface UseCachedQueryResult<T> {
+  /** Current data (may be cached, optimistic, or fresh). */
+  data: T | undefined;
+  /** True during initial load (no cached data available yet). */
+  isLoading: boolean;
+  /** True when fetching in background (data may be stale-while-revalidate). */
+  isFetching: boolean;
+  /** Manually trigger a refetch, bypassing cache. */
+  refetch: () => Promise<T>;
+  /**
+   * Set an optimistic value.
+   * This "pins" the value so polling won't overwrite it.
+   * Pin duration defaults to 10s or until the next successful refetch.
+   */
+  setOptimistic: (value: T | ((prev: T | undefined) => T)) => void;
+}
+
+export function makeCacheKey(instanceCacheKey: string, method: string, args: unknown[] = []): string {
+  let serializedArgs = "";
+  try {
+    serializedArgs = args.length > 0 ? JSON.stringify(args) : "";
+  } catch {
+    serializedArgs = String(args.length);
+  }
+  return serializedArgs ? `${instanceCacheKey}:${method}:${serializedArgs}` : `${instanceCacheKey}:${method}`;
+}
+
+export function useCachedQuery<T>(
+  key: string,
+  fetcher: () => Promise<T>,
+  options: UseCachedQueryOptions = {},
+): UseCachedQueryResult<T> {
+  const {
+    pollInterval = 0,
+    ttlMs = 10_000,
+    enabled = true,
+    skipWhenPending = false,
+  } = options;
+
+  const fetcherRef = useRef(fetcher);
+  fetcherRef.current = fetcher;
+
+  const hasPendingRef = useRef(false);
+  const [isFetching, setIsFetching] = useState(false);
+
+  // Subscribe to cache entry changes
+  const subscribeToKey = useCallback(
+    (onStoreChange: () => void) => _subscribe(key, onStoreChange),
+    [key],
+  );
+
+  const getSnapshot = useCallback(() => {
+    const entry = _getEntry<T>(key);
+    return entry?.value;
+  }, [key]);
+
+  // useSyncExternalStore ensures React re-renders when cache changes
+  const data = useSyncExternalStore(subscribeToKey, getSnapshot, getSnapshot);
+
+  // Fetch data, respecting optimistic pins
+  const doFetch = useCallback(async (force = false): Promise<T> => {
+    const now = Date.now();
+    const entry = _getEntry<T>(key);
+
+    // If pinned (optimistic), don't overwrite unless forced
+    if (!force && entry && entry.optimisticUntil > now) {
+      return entry.value as T;
+    }
+
+    // If cached and not expired, return cached
+    if (!force && entry && entry.expiresAt > now && entry.value !== undefined) {
+      return entry.value;
+    }
+
+    // If already fetching, join the in-flight request
+    if (entry?.inFlight) {
+      return entry.inFlight;
+    }
+
+    setIsFetching(true);
+    const request = fetcherRef.current();
+
+    // Mark in-flight
+    _setEntry<T>(key, { inFlight: request as Promise<T> });
+
+    try {
+      const result = await request;
+      const currentEntry = _getEntry<T>(key);
+
+      // Only update if not pinned by a newer optimistic write
+      if (!currentEntry || currentEntry.optimisticUntil <= Date.now()) {
+        _setEntry<T>(key, {
+          value: result,
+          expiresAt: Date.now() + ttlMs,
+          optimisticUntil: 0,
+          inFlight: null,
+        });
+      } else {
+        // Just clear inFlight, keep the optimistic value
+        _setEntry<T>(key, { inFlight: null });
+      }
+
+      _trimIfNeeded();
+      return result;
+    } catch (error) {
+      // On error, clear inFlight but keep stale data
+      const currentEntry = _getEntry<T>(key);
+      if (currentEntry?.inFlight === request) {
+        _setEntry<T>(key, { inFlight: null });
+      }
+      throw error;
+    } finally {
+      setIsFetching(false);
+    }
+  }, [key, ttlMs]);
+
+  const refetch = useCallback(() => doFetch(true), [doFetch]);
+
+  // Set optimistic value
+  const setOptimistic = useCallback(
+    (valueOrUpdater: T | ((prev: T | undefined) => T)) => {
+      const entry = _getEntry<T>(key);
+      const prev = entry?.value;
+      const nextValue = typeof valueOrUpdater === "function"
+        ? (valueOrUpdater as (prev: T | undefined) => T)(prev)
+        : valueOrUpdater;
+      setOptimisticCacheValue(key, nextValue);
+    },
+    [key],
+  );
+
+  // Initial fetch
+  useEffect(() => {
+    if (!enabled) return;
+    doFetch().catch(() => {});
+  }, [enabled, doFetch]);
+
+  // Polling
+  useEffect(() => {
+    if (!enabled || pollInterval <= 0) return;
+
+    const interval = setInterval(() => {
+      if (skipWhenPending && hasPendingRef.current) return;
+      doFetch().catch(() => {});
+    }, pollInterval);
+
+    return () => clearInterval(interval);
+  }, [enabled, pollInterval, skipWhenPending, doFetch]);
+
+  // Refetch when cache entry is invalidated (generation changes but value cleared)
+  useEffect(() => {
+    if (!enabled) return;
+    const entry = _getEntry<T>(key);
+    if (entry && entry.expiresAt === 0 && entry.value === undefined && !entry.inFlight) {
+      doFetch().catch(() => {});
+    }
+  }, [enabled, key, data, doFetch]);
+
+  const isLoading = data === undefined && !isFetching;
+
+  return {
+    data,
+    isLoading: data === undefined,
+    isFetching,
+    refetch,
+    setOptimistic,
+  };
+}
+
+/**
+ * Helper to create a mutation wrapper that invalidates related cache keys after success.
+ *
+ * Usage:
+ *   const deleteFn = useMutation(
+ *     (id: string) => api.deleteItem(id),
+ *     { invalidate: [agentsCacheKey, statusCacheKey] }
+ *   );
+ */
+export function createMutationWrapper<TArgs extends unknown[], TResult>(
+  fn: (...args: TArgs) => Promise<TResult>,
+  options: { invalidate?: string[] } = {},
+): (...args: TArgs) => Promise<TResult> {
+  return async (...args: TArgs) => {
+    const result = await fn(...args);
+    if (options.invalidate) {
+      invalidateAndRefetch(options.invalidate);
+    }
+    return result;
+  };
+}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -95,8 +95,22 @@ export function Home({
 
   // Skip polling refreshes while there are queued commands (to preserve optimistic UI)
   const hasPendingRef = useRef(false);
+  // Timestamp until which polls should not overwrite optimistic component state.
+  // This closes the race window between queueCommand() and the next queuedCommandsCount() poll.
+  const optimisticLockedUntilRef = useRef(0);
+
+  /** Mark state as optimistically locked for the given duration. */
+  const lockOptimistic = useCallback((durationMs = 15_000) => {
+    optimisticLockedUntilRef.current = Date.now() + durationMs;
+    hasPendingRef.current = true;
+  }, []);
+
   useEffect(() => {
-    const check = () => { ua.queuedCommandsCount().then((n) => { hasPendingRef.current = n > 0; }).catch(() => {}); };
+    const check = () => { ua.queuedCommandsCount().then((n) => {
+      // Don't clear the flag if we're within the optimistic lock window
+      if (optimisticLockedUntilRef.current > Date.now()) return;
+      hasPendingRef.current = n > 0;
+    }).catch(() => {}); };
     check();
     const interval = setInterval(check, ua.isRemote ? 10000 : 3000);
     return () => clearInterval(interval);
@@ -194,7 +208,7 @@ export function Home({
 
   const fetchStatus = useCallback(() => {
     if (ua.isRemote && !ua.isConnected) return; // Wait for SSH connection
-    if (hasPendingRef.current) return; // Don't overwrite optimistic UI
+    if (hasPendingRef.current || optimisticLockedUntilRef.current > Date.now()) return; // Don't overwrite optimistic UI
     if (statusInFlightRef.current) return; // Prevent overlapping polls
     statusInFlightRef.current = true;
     ua.getInstanceStatus().then((s) => {
@@ -281,7 +295,7 @@ export function Home({
 
   const refreshAgents = useCallback(() => {
     if (ua.isRemote && !ua.isConnected) return; // Wait for SSH connection
-    if (hasPendingRef.current) return; // Don't overwrite optimistic UI
+    if (hasPendingRef.current || optimisticLockedUntilRef.current > Date.now()) return; // Don't overwrite optimistic UI
     ua.listAgents().then((a) => {
       setAgents(a);
       if (ua.isRemote) remoteErrorShownRef.current = false;
@@ -383,12 +397,15 @@ export function Home({
 
   const handleDeleteAgent = (agentId: string) => {
     if (ua.isRemote && !ua.isConnected) return;
+    lockOptimistic();
     ua.queueCommand(
       `Delete agent: ${agentId}`,
       ["openclaw", "agents", "delete", agentId, "--force"],
     ).then(() => {
-      // Optimistic UI update
-      setAgents((prev) => prev?.filter((a) => a.id !== agentId) ?? null);
+      // Optimistic UI update + pin in cache so polling doesn't overwrite
+      const updated = agents?.filter((a) => a.id !== agentId) ?? null;
+      setAgents(updated);
+      if (updated) ua.pinOptimistic("listAgents", updated);
     }).catch((e) => { if (!hasGuidanceEmitted(e)) showToast?.(String(e), "error"); });
   };
 
@@ -454,6 +471,8 @@ export function Home({
                   if (val === "__raw__") return;
                   setSavingModel(true);
                   const modelValue = resolveModelValue(val === "__none__" ? null : val);
+                  // Lock optimistic state immediately to prevent polls from overwriting
+                  lockOptimistic();
                   const p = modelValue
                     ? ua.queueCommand(
                         `Set global model: ${modelValue}`,
@@ -463,10 +482,9 @@ export function Home({
                         "Clear global model override",
                         ["openclaw", "config", "unset", "agents.defaults.model.primary"],
                       );
-                  p.then(() => {
-                    // Optimistic UI update
-                    setStatus((prev) => prev ? { ...prev, globalDefaultModel: modelValue ?? "" } : prev);
-                  }).catch((e) => { if (!hasGuidanceEmitted(e)) showToast?.(String(e), "error"); })
+                  // Optimistic UI update — applied immediately, protected by lockOptimistic
+                  setStatus((prev) => prev ? { ...prev, globalDefaultModel: modelValue ?? "" } : prev);
+                  p.catch((e) => { if (!hasGuidanceEmitted(e)) showToast?.(String(e), "error"); })
                     .finally(() => setSavingModel(false));
                 }}
                 disabled={savingModel}
@@ -514,6 +532,7 @@ export function Home({
                           className="h-5 w-5 p-0 text-muted-foreground hover:text-foreground"
                           disabled={idx === 0}
                           onClick={() => {
+                            lockOptimistic();
                             const arr = [...(status.fallbackModels ?? [])];
                             [arr[idx - 1], arr[idx]] = [arr[idx], arr[idx - 1]];
                             setStatus((prev) => prev ? { ...prev, fallbackModels: arr } : prev);
@@ -531,6 +550,7 @@ export function Home({
                           className="h-5 w-5 p-0 text-muted-foreground hover:text-foreground"
                           disabled={idx === (status.fallbackModels ?? []).length - 1}
                           onClick={() => {
+                            lockOptimistic();
                             const arr = [...(status.fallbackModels ?? [])];
                             [arr[idx], arr[idx + 1]] = [arr[idx + 1], arr[idx]];
                             setStatus((prev) => prev ? { ...prev, fallbackModels: arr } : prev);
@@ -547,6 +567,7 @@ export function Home({
                           variant="ghost"
                           className="h-5 w-5 p-0 text-muted-foreground hover:text-destructive"
                           onClick={() => {
+                            lockOptimistic();
                             const arr = (status.fallbackModels ?? []).filter((_, i) => i !== idx);
                             setStatus((prev) => prev ? { ...prev, fallbackModels: arr } : prev);
                             const cmd = arr.length > 0
@@ -573,6 +594,7 @@ export function Home({
                     if (!val) return;
                     const modelValue = resolveModelValue(val);
                     if (!modelValue) return;
+                    lockOptimistic();
                     const arr = [...(status.fallbackModels ?? []), modelValue];
                     setStatus((prev) => prev ? { ...prev, fallbackModels: arr } : prev);
                     ua.queueCommand(
@@ -646,6 +668,7 @@ export function Home({
                           })()}
                           onValueChange={async (val) => {
                             const modelValue = resolveModelValue(val === "__none__" ? null : val);
+                            lockOptimistic();
                             try {
                               // Find agent index in config list
                               const raw = await ua.readRawConfig();
@@ -665,10 +688,12 @@ export function Home({
                                 // Agent not in list yet — append
                                 await ua.queueCommand(label, ["openclaw", "config", "set", `agents.list.${list.length}`, JSON.stringify({ id: agent.id, model: modelValue }), "--json"]);
                               }
-                              // Optimistic UI update
-                              setAgents((prev) => prev?.map((a) =>
+                              // Optimistic UI update + pin in cache
+                              const updated = agents?.map((a) =>
                                 a.id === agent.id ? { ...a, model: modelValue ?? null } : a
-                              ) ?? null);
+                              ) ?? null;
+                              setAgents(updated);
+                              if (updated) ua.pinOptimistic("listAgents", updated);
                             } catch (e) {
                               if (!hasGuidanceEmitted(e)) showToast?.(String(e), "error");
                             }


### PR DESCRIPTION
## Summary

修复 UI 缓存导致的数据状态不一致问题。更新数据后 UI 出现旧数据闪回、新旧状态冲突、刷新后先显示旧数据等问题。

Closes #59

## Root Cause

双层状态架构的竞态条件：
1. 组件 `useState` 持有 optimistic 新数据
2. `API_READ_CACHE` 持有 TTL 缓存旧数据
3. 轮询触发时，从缓存读到旧数据覆盖了 optimistic 新数据 → UI 闪回

```
mutation → setStatus(newVal) → poll fires → callWithReadCache(stale) → setStatus(oldVal) → 闪回
```

## Changes

### `src/lib/use-api.ts` — Cache layer enhancement
- 给 `ApiReadCacheEntry` 增加 `optimisticUntil` 字段
- `callWithReadCache` 检测 pinned 值，不覆盖 optimistic 数据
- 新增 subscriber 通知机制（`subscribeToCacheKey`、`_notifyCacheSubscribers`）
- 导出 `setOptimisticReadCache`、`readCacheValue`、`buildCacheKey`
- `useApi` 增加 `pinOptimistic`/`pinOptimisticGlobal` 方法

### `src/pages/Home.tsx` — Fix all mutation handlers
- 新增 `lockOptimistic()` — mutation 时立即锁定 15s，阻止轮询覆写
- 修复 `queueCommand()` 和 `queuedCommandsCount()` 轮询之间的竞态窗口
- 删除/改模型后 `pinOptimistic("listAgents", ...)` 固定缓存
- Optimistic update 改为同步执行（不再放在 `.then()` 回调里）

### `src/lib/use-cached-query.ts` — New reactive hook (future use)
- `useCachedQuery`: cache-first + polling + optimistic pinning + SWR
- 替代 `useState + useEffect + setInterval` 反模式
- 可供其他页面逐步迁移

### `src/lib/__tests__/use-api-cache.test.ts` — Tests
- 缓存原语测试：`buildCacheKey`、optimistic pin、invalidation

## Testing
- `bun run tsc --noEmit` ✅
- `bun test` — 77 tests pass ✅
- Manual: mutation → UI 不再闪回旧数据