### PR TITLE
fix: correct bundle output path in pr-build workflow

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -95,7 +95,7 @@ jobs:
         shell: bash
         run: |
           mkdir -p artifacts
-          BUNDLE_DIR="src-tauri/target/${{ matrix.target }}/release/bundle"
+          BUNDLE_DIR="target/${{ matrix.target }}/release/bundle"
 
           find "$BUNDLE_DIR" -type f \( \
             -name "*.dmg" -o \


### PR DESCRIPTION
## Problem

PR build workflow (`pr-build.yml`) collects zero artifacts because the bundle path is wrong.

`tauri-action` with `--target <triple>` outputs bundles to:
```
target/<triple>/release/bundle/
```

But the collect step was looking in:
```
src-tauri/target/<triple>/release/bundle/
```

CI logs confirm builds succeed and produce .deb/.rpm/.AppImage/.dmg/.msi, but `find` in the wrong directory returns nothing → 0 artifacts uploaded.

## Fix

Remove the `src-tauri/` prefix from `BUNDLE_DIR`.

## Evidence

From [PR #62 build run](https://github.com/zhixianio/clawpal/actions/runs/22610131788) (Linux-x64 job):
```
Bundling ClawPal_0.3.2_amd64.deb (/home/runner/work/clawpal/clawpal/target/x86_64-unknown-linux-gnu/release/bundle/deb/...)
...
Collected artifacts:
total 0
```