### PR TITLE
fix(ci): sync pr-build bundle path into issue-55 branch

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -95,7 +95,7 @@ jobs:
         shell: bash
         run: |
           mkdir -p artifacts
-          BUNDLE_DIR="src-tauri/target/${{ matrix.target }}/release/bundle"
+          BUNDLE_DIR="target/${{ matrix.target }}/release/bundle"
 
           find "$BUNDLE_DIR" -type f \( \
             -name "*.dmg" -o \


### PR DESCRIPTION
## Summary
- sync CI fix for PR build artifact bundle path into `fix/issue-55`
- keeps `.github/workflows/pr-build.yml` output path consistent with actual bundle location

## Why
`fix/issue-55` does not include this workflow correction yet. Bringing it in avoids PR build artifact path mismatch and reduces CI/review friction for this branch.

## Scope
- CI workflow only
- file changed: `.github/workflows/pr-build.yml`
- no runtime/product code changes
