### PR TITLE
test(ci): verify pr-build bundle-path fix on develop

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -95,7 +95,7 @@ jobs:
         shell: bash
         run: |
           mkdir -p artifacts
-          BUNDLE_DIR="src-tauri/target/${{ matrix.target }}/release/bundle"
+          BUNDLE_DIR="target/${{ matrix.target }}/release/bundle"
 
           find "$BUNDLE_DIR" -type f \( \
             -name "*.dmg" -o \


### PR DESCRIPTION
Test rebase branch onto develop to verify CI behavior for the PR build bundle-path fix.

- base: develop
- head: Akane-CN:test/rebase-prbuild-on-develop
- change scope: `.github/workflows/pr-build.yml` only
