### PR TITLE
chore: draft-first release flow with conditional signing

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -19,10 +19,19 @@ on:
 
 permissions:
   contents: write
+  actions: write
+
+concurrency:
+  group: bump-version-${{ github.ref_name }}
+  cancel-in-progress: false
 
 jobs:
-  bump:
+  prepare:
     runs-on: ubuntu-latest
+    outputs:
+      current_version: ${{ steps.version.outputs.current }}
+      new_version: ${{ steps.version.outputs.new }}
+      is_prerelease: ${{ steps.version.outputs.is_prerelease }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -40,65 +49,381 @@ jobs:
           CURRENT=$(node -p "require('./package.json').version")
           echo "current=$CURRENT" >> "$GITHUB_OUTPUT"
 
-          if [ "${{ inputs.bump_type }}" = "custom" ]; then
+          BUMP_TYPE="${{ inputs.bump_type }}"
+          SEMVER_REGEX='^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-((0|[1-9][0-9]*|[0-9A-Za-z-][0-9A-Za-z-]*)(\.(0|[1-9][0-9]*|[0-9A-Za-z-][0-9A-Za-z-]*))*))?(\+([0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*))?$'
+
+          if [ "$BUMP_TYPE" = "custom" ]; then
             NEW="${{ inputs.custom_version }}"
             if [ -z "$NEW" ]; then
               echo "::error::custom_version is required when bump_type is 'custom'"
               exit 1
             fi
-            # Basic semver validation (allows pre-release and build metadata)
-            if ! echo "$NEW" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?(\+[a-zA-Z0-9.]+)?$'; then
-              echo "::error::Invalid version format: $NEW (expected semver, e.g. 1.2.3 or 1.0.0-beta.1)"
+            if ! echo "$NEW" | grep -qE "$SEMVER_REGEX"; then
+              echo "::error::Invalid custom version: $NEW (must follow semver)"
               exit 1
             fi
           else
-            IFS='.' read -r MAJOR MINOR PATCH <<< "${CURRENT%%-*}"
-            case "${{ inputs.bump_type }}" in
+            BASE="${CURRENT%%[-+]*}"
+            IFS='.' read -r MAJOR MINOR PATCH <<< "$BASE"
+            case "$BUMP_TYPE" in
               major) NEW="$((MAJOR + 1)).0.0" ;;
               minor) NEW="${MAJOR}.$((MINOR + 1)).0" ;;
               patch) NEW="${MAJOR}.${MINOR}.$((PATCH + 1))" ;;
             esac
           fi
 
-          echo "new=$NEW" >> "$GITHUB_OUTPUT"
-          echo "### Version bump: $CURRENT → $NEW" >> "$GITHUB_STEP_SUMMARY"
+          if ! echo "$NEW" | grep -qE "$SEMVER_REGEX"; then
+            echo "::error::Computed version is invalid semver: $NEW"
+            exit 1
+          fi
 
-      - name: Determine if prerelease
-        id: release_flags
-        run: |
-          NEW="${{ steps.version.outputs.new }}"
-          if [[ "$NEW" == *-alpha* || "$NEW" == *-beta* || "$NEW" == *-rc* ]]; then
+          if [ "$NEW" = "$CURRENT" ]; then
+            echo "::error::New version equals current version ($CURRENT)"
+            exit 1
+          fi
+
+          if git show-ref --tags --verify --quiet "refs/tags/v$NEW"; then
+            echo "::error::Tag v$NEW already exists locally"
+            exit 1
+          fi
+
+          if git ls-remote --exit-code --tags origin "refs/tags/v$NEW" >/dev/null 2>&1; then
+            echo "::error::Tag v$NEW already exists on origin"
+            exit 1
+          fi
+
+          echo "new=$NEW" >> "$GITHUB_OUTPUT"
+
+          if [[ "$NEW" == *-* ]]; then
             echo "is_prerelease=true" >> "$GITHUB_OUTPUT"
             echo "### Tag type: prerelease" >> "$GITHUB_STEP_SUMMARY"
           else
             echo "is_prerelease=false" >> "$GITHUB_OUTPUT"
             echo "### Tag type: release" >> "$GITHUB_STEP_SUMMARY"
           fi
+          echo "### Version bump: $CURRENT → $NEW" >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Update package.json
-        run: |
-          npm version "${{ steps.version.outputs.new }}" --no-git-tag-version
+  test_ci:
+    name: Test CI
+    needs: prepare
+    runs-on: ubuntu-latest
+    env:
+      VERSION: ${{ needs.prepare.outputs.new_version }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
 
-      - name: Update src-tauri/Cargo.toml
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Apply version to source files
         run: |
-          sed -i "0,/^version = \".*\"/s//version = \"${{ steps.version.outputs.new }}\"/" src-tauri/Cargo.toml
+          node - <<'NODE'
+          const fs = require("fs");
+          const version = process.env.VERSION;
+
+          const pkgPath = "package.json";
+          const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf8"));
+          pkg.version = version;
+          fs.writeFileSync(pkgPath, `${JSON.stringify(pkg, null, 2)}\n`);
+
+          const cargoPath = "src-tauri/Cargo.toml";
+          const cargoContent = fs.readFileSync(cargoPath, "utf8");
+          const cargoVersionRegex = /^version\s*=\s*".*"/m;
+          if (!cargoVersionRegex.test(cargoContent)) {
+            throw new Error("Failed to locate version field in src-tauri/Cargo.toml");
+          }
+          fs.writeFileSync(
+            cargoPath,
+            cargoContent.replace(cargoVersionRegex, `version = "${version}"`)
+          );
+          NODE
 
       - name: Update Cargo.lock
         run: |
-          cd src-tauri && cargo update -p clawpal --precise "${{ steps.version.outputs.new }}" 2>/dev/null || true
-          cd .. && cargo generate-lockfile 2>/dev/null || true
+          cd src-tauri
+          cargo update -p clawpal --precise "$VERSION" 2>/dev/null || true
+          cargo generate-lockfile 2>/dev/null || true
 
-      - name: Commit, tag, and push
+      - name: Install frontend dependencies
+        run: |
+          bun install --frozen-lockfile
+
+      - name: Type check
+        run: bun run typecheck
+
+      - name: Build frontend
+        run: bun run build
+
+      - name: Install Linux dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            libappindicator3-dev \
+            librsvg2-dev \
+            patchelf \
+            libssl-dev \
+            libgtk-3-dev \
+            libsoup-3.0-dev \
+            libjavascriptcoregtk-4.1-dev
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+        working-directory: src-tauri
+
+      - name: Run clippy
+        run: cargo clippy -p clawpal-core -- -D warnings
+        working-directory: src-tauri
+
+      - name: Run tests
+        run: cargo test -p clawpal-core
+        working-directory: src-tauri
+
+  package_ci:
+    name: Package CI (${{ matrix.label }})
+    needs: prepare
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: macos-latest
+            target: aarch64-apple-darwin
+            label: macOS-ARM64
+          - platform: macos-latest
+            target: x86_64-apple-darwin
+            label: macOS-x64
+          - platform: ubuntu-22.04
+            target: x86_64-unknown-linux-gnu
+            label: Linux-x64
+          - platform: windows-latest
+            target: x86_64-pc-windows-msvc
+            label: Windows-x64
+    runs-on: ${{ matrix.platform }}
+    env:
+      VERSION: ${{ needs.prepare.outputs.new_version }}
+      IS_PRERELEASE: ${{ needs.prepare.outputs.is_prerelease }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Rust cache
+        uses: swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+
+      - name: Apply version to source files
+        shell: bash
+        run: |
+          node - <<'NODE'
+          const fs = require("fs");
+          const version = process.env.VERSION;
+
+          const pkgPath = "package.json";
+          const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf8"));
+          pkg.version = version;
+          fs.writeFileSync(pkgPath, `${JSON.stringify(pkg, null, 2)}\n`);
+
+          const cargoPath = "src-tauri/Cargo.toml";
+          const cargoContent = fs.readFileSync(cargoPath, "utf8");
+          const cargoVersionRegex = /^version\s*=\s*".*"/m;
+          if (!cargoVersionRegex.test(cargoContent)) {
+            throw new Error("Failed to locate version field in src-tauri/Cargo.toml");
+          }
+          fs.writeFileSync(
+            cargoPath,
+            cargoContent.replace(cargoVersionRegex, `version = "${version}"`)
+          );
+          NODE
+
+      - name: Update Cargo.lock
+        shell: bash
+        run: |
+          cd src-tauri
+          cargo update -p clawpal --precise "$VERSION" 2>/dev/null || true
+          cargo generate-lockfile 2>/dev/null || true
+
+      - name: Install Linux dependencies
+        if: matrix.platform == 'ubuntu-22.04'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            libappindicator3-dev \
+            librsvg2-dev \
+            patchelf \
+            libssl-dev \
+            libgtk-3-dev \
+            libsoup-3.0-dev \
+            libjavascriptcoregtk-4.1-dev
+
+      - name: Disable code signing for package CI
+        shell: bash
+        run: |
+          node << 'EOF'
+          const fs = require("fs");
+          const conf = JSON.parse(fs.readFileSync("src-tauri/tauri.conf.json", "utf8"));
+          conf.bundle.createUpdaterArtifacts = false;
+          if (conf.bundle.macOS) conf.bundle.macOS.signingIdentity = "-";
+          fs.writeFileSync("src-tauri/tauri.conf.json", JSON.stringify(conf, null, 2));
+          EOF
+
+      - name: Install frontend dependencies
+        run: npm ci
+
+      - name: Compute build args
+        id: build_args
+        shell: bash
+        run: |
+          args="--target ${{ matrix.target }}"
+          if [ "${{ matrix.platform }}" = "windows-latest" ] && [ "$IS_PRERELEASE" = "true" ]; then
+            args+=" --bundles nsis"
+          fi
+          echo "args=$args" >> "$GITHUB_OUTPUT"
+
+      - name: Build Tauri app
+        uses: tauri-apps/tauri-action@v0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          args: ${{ steps.build_args.outputs.args }}
+
+      - name: Collect build artifacts
+        shell: bash
+        run: |
+          mkdir -p artifacts
+          BUNDLE_DIR="src-tauri/target/${{ matrix.target }}/release/bundle"
+
+          find "$BUNDLE_DIR" -type f \( \
+            -name "*.dmg" -o \
+            -name "*.deb" -o \
+            -name "*.AppImage" -o \
+            -name "*.msi" -o \
+            -name "*.exe" -o \
+            -name "*.rpm" \
+          \) -exec cp {} artifacts/ \; 2>/dev/null || true
+
+          if [ "${{ matrix.platform }}" = "windows-latest" ]; then
+            PORTABLE="src-tauri/target/${{ matrix.target }}/release/clawpal.exe"
+            [ -f "$PORTABLE" ] && cp "$PORTABLE" "artifacts/ClawPal_portable.exe"
+          fi
+
+          echo "### Collected artifacts:"
+          ls -lh artifacts/ || echo "No artifacts found"
+
+      - name: Upload package CI artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: bump-version-${{ matrix.label }}
+          path: artifacts/*
+          retention-days: 7
+          if-no-files-found: warn
+
+  publish:
+    name: Commit and Trigger Draft Release
+    needs: [prepare, test_ci, package_ci]
+    runs-on: ubuntu-latest
+    env:
+      VERSION: ${{ needs.prepare.outputs.new_version }}
+      IS_PRERELEASE: ${{ needs.prepare.outputs.is_prerelease }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.ref_name }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Apply version to source files
+        run: |
+          node - <<'NODE'
+          const fs = require("fs");
+          const version = process.env.VERSION;
+
+          const pkgPath = "package.json";
+          const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf8"));
+          pkg.version = version;
+          fs.writeFileSync(pkgPath, `${JSON.stringify(pkg, null, 2)}\n`);
+
+          const cargoPath = "src-tauri/Cargo.toml";
+          const cargoContent = fs.readFileSync(cargoPath, "utf8");
+          const cargoVersionRegex = /^version\s*=\s*".*"/m;
+          if (!cargoVersionRegex.test(cargoContent)) {
+            throw new Error("Failed to locate version field in src-tauri/Cargo.toml");
+          }
+          fs.writeFileSync(
+            cargoPath,
+            cargoContent.replace(cargoVersionRegex, `version = "${version}"`)
+          );
+          NODE
+
+      - name: Update Cargo.lock
+        run: |
+          cd src-tauri
+          cargo update -p clawpal --precise "$VERSION" 2>/dev/null || true
+          cargo generate-lockfile 2>/dev/null || true
+
+      - name: Commit and push version bump
+        id: commit_push
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-          git add -A
+          git add package.json src-tauri/Cargo.toml src-tauri/Cargo.lock
           git diff --cached --quiet && { echo "No changes to commit"; exit 1; }
 
-          NEW="${{ steps.version.outputs.new }}"
-          git commit -m "chore: bump version to ${NEW}"
-          echo "Bumping to prerelease: ${{ steps.release_flags.outputs.is_prerelease }}"
-          git tag "v${NEW}"
-          git push origin HEAD
-          git push origin "v${NEW}"
+          git commit -m "chore: bump version to ${VERSION}"
+          echo "Bumping to prerelease: $IS_PRERELEASE"
+          git push origin "HEAD:${GITHUB_REF_NAME}"
+
+          COMMIT_SHA=$(git rev-parse HEAD)
+          echo "commit_sha=$COMMIT_SHA" >> "$GITHUB_OUTPUT"
+
+      - name: Trigger Release workflow (draft)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COMMIT_SHA: ${{ steps.commit_push.outputs.commit_sha }}
+        run: |
+          gh workflow run release.yml \
+            --ref "${GITHUB_REF_NAME}" \
+            -f version="${VERSION}" \
+            -f target_commitish="${COMMIT_SHA}" \
+            -f is_prerelease="${IS_PRERELEASE}"
+
+      - name: Release trigger summary
+        run: |
+          echo "### Release draft trigger" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Pushed branch commit: ${GITHUB_REF_NAME}@${{ steps.commit_push.outputs.commit_sha }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Tag to be created on publish: v${VERSION}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Prerelease: ${IS_PRERELEASE}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Next: \`Release\` workflow is dispatched to create/update draft release (without pushing tag)." >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,20 @@
 name: Release
 
 on:
-  push:
-    tags: ['v*']
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Semver version without v prefix (e.g. 1.2.3 or 1.2.3-rc.1)"
+        required: true
+        type: string
+      target_commitish:
+        description: "Commit SHA to anchor the draft release/tag"
+        required: true
+        type: string
+      is_prerelease:
+        description: "Whether this should be marked as prerelease"
+        required: true
+        type: boolean
 
 permissions:
   contents: write
@@ -17,18 +29,18 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{ inputs.target_commitish }}
 
       - name: Generate changelog
         id: changelog
         run: |
-          TAG="${GITHUB_REF_NAME}"
-          # Find previous tag
-          PREV_TAG=$(git tag --sort=-v:refname | grep -v "^${TAG}$" | head -1)
+          TARGET_COMMIT="${{ inputs.target_commitish }}"
+          PREV_TAG=$(git tag --sort=-v:refname | head -1)
 
           if [ -z "$PREV_TAG" ]; then
-            COMMITS=$(git log --oneline --no-merges "${TAG}")
+            COMMITS=$(git log --oneline --no-merges "$TARGET_COMMIT")
           else
-            COMMITS=$(git log --oneline --no-merges "${PREV_TAG}..${TAG}")
+            COMMITS=$(git log --oneline --no-merges "${PREV_TAG}..${TARGET_COMMIT}")
           fi
 
           # Group commits by type
@@ -80,10 +92,14 @@ jobs:
 
     runs-on: ${{ matrix.platform }}
     name: Build (${{ matrix.label }})
+    environment: ${{ inputs.is_prerelease && 'prerelease' || 'release' }}
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.target_commitish }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -101,19 +117,30 @@ jobs:
         with:
           workspaces: src-tauri
 
-      - name: Sync project version from tag
-        id: sync_version
+      - name: Resolve release metadata
+        id: release_meta
         shell: bash
         run: |
-          VERSION="${GITHUB_REF_NAME#v}"
+          VERSION="${{ inputs.version }}"
           if [ -z "$VERSION" ]; then
-            echo "::error::Tag name is empty"
+            echo "::error::Version input is empty"
             exit 1
           fi
           if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?(\+[a-zA-Z0-9.]+)?$'; then
-            echo "::error::Invalid semver tag: $VERSION"
+            echo "::error::Invalid semver version: $VERSION"
             exit 1
           fi
+
+          TAG="v$VERSION"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "### Release tag: $TAG" >> "$GITHUB_STEP_SUMMARY"
+          echo "### Target commit: ${{ inputs.target_commitish }}" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Sync project version from dispatch input
+        shell: bash
+        run: |
+          VERSION="${{ steps.release_meta.outputs.version }}"
 
           export VERSION
           node - <<'NODE'
@@ -138,6 +165,89 @@ jobs:
 
           echo "### Synced project version to $VERSION" >> "$GITHUB_STEP_SUMMARY"
 
+      - name: Determine if prerelease
+        id: release_flags
+        shell: bash
+        run: |
+          VERSION="${{ steps.release_meta.outputs.version }}"
+          if [ "${{ inputs.is_prerelease }}" = "true" ] || [[ "$VERSION" == *-* ]]; then
+            echo "is_prerelease=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_prerelease=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Detect signing materials
+        id: signing
+        shell: bash
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+          APPLE_API_KEY_CONTENT: ${{ secrets.APPLE_API_KEY_CONTENT }}
+        run: |
+          has_tauri_signing=true
+          [ -z "$TAURI_SIGNING_PRIVATE_KEY" ] && has_tauri_signing=false
+          [ -z "$TAURI_SIGNING_PRIVATE_KEY_PASSWORD" ] && has_tauri_signing=false
+
+          has_apple_signing=true
+          [ -z "$APPLE_CERTIFICATE" ] && has_apple_signing=false
+          [ -z "$APPLE_CERTIFICATE_PASSWORD" ] && has_apple_signing=false
+          [ -z "$APPLE_SIGNING_IDENTITY" ] && has_apple_signing=false
+          [ -z "$APPLE_API_KEY" ] && has_apple_signing=false
+          [ -z "$APPLE_API_ISSUER" ] && has_apple_signing=false
+          [ -z "$APPLE_API_KEY_CONTENT" ] && has_apple_signing=false
+
+          should_sign=false
+          if [ "$has_tauri_signing" = "true" ] && [ "$has_apple_signing" = "true" ]; then
+            should_sign=true
+          fi
+
+          if [ "$should_sign" = "true" ]; then
+            mode="signed"
+            asset_suffix=""
+          else
+            mode="unsigned"
+            asset_suffix="-unsigned"
+          fi
+
+          echo "has_tauri_signing=$has_tauri_signing" >> "$GITHUB_OUTPUT"
+          echo "has_apple_signing=$has_apple_signing" >> "$GITHUB_OUTPUT"
+          echo "should_sign=$should_sign" >> "$GITHUB_OUTPUT"
+          echo "mode=$mode" >> "$GITHUB_OUTPUT"
+          echo "asset_suffix=$asset_suffix" >> "$GITHUB_OUTPUT"
+
+      - name: Summarize signing mode
+        shell: bash
+        run: |
+          echo "### Signing mode (${{ matrix.label }})" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Environment: ${{ inputs.is_prerelease && 'prerelease' || 'release' }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- has_tauri_signing: ${{ steps.signing.outputs.has_tauri_signing }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- has_apple_signing: ${{ steps.signing.outputs.has_apple_signing }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- mode: ${{ steps.signing.outputs.mode }}" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Disable app signing when signing material is missing
+        if: steps.signing.outputs.should_sign != 'true'
+        shell: bash
+        run: |
+          node - <<'NODE'
+          const fs = require("fs");
+          const path = "src-tauri/tauri.conf.json";
+          const conf = JSON.parse(fs.readFileSync(path, "utf8"));
+
+          if (conf.bundle) {
+            conf.bundle.createUpdaterArtifacts = false;
+            if (conf.bundle.macOS) {
+              conf.bundle.macOS.signingIdentity = "-";
+            }
+          }
+
+          fs.writeFileSync(path, JSON.stringify(conf, null, 2));
+          NODE
+
       - name: Install Linux dependencies
         if: matrix.platform == 'ubuntu-22.04'
         run: |
@@ -149,7 +259,7 @@ jobs:
             patchelf
 
       - name: Import Apple certificate (macOS only)
-        if: ${{ contains(matrix.target, 'apple-darwin') && !contains(github.ref_name, '-alpha') && !contains(github.ref_name, '-beta') && !contains(github.ref_name, '-rc') }}
+        if: ${{ contains(matrix.target, 'apple-darwin') && steps.signing.outputs.should_sign == 'true' }}
         env:
           APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
           APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
@@ -177,7 +287,7 @@ jobs:
           rm "$CERTIFICATE_PATH"
 
       - name: Write Apple API key (macOS only)
-        if: ${{ contains(matrix.target, 'apple-darwin') && !contains(github.ref_name, '-alpha') && !contains(github.ref_name, '-beta') && !contains(github.ref_name, '-rc') }}
+        if: ${{ contains(matrix.target, 'apple-darwin') && steps.signing.outputs.should_sign == 'true' }}
         env:
           APPLE_API_KEY_CONTENT: ${{ secrets.APPLE_API_KEY_CONTENT }}
         run: |
@@ -186,16 +296,6 @@ jobs:
 
       - name: Install frontend dependencies
         run: npm ci
-
-      - name: Determine if prerelease
-        id: release_flags
-        shell: bash
-        run: |
-          if [[ "${{ github.ref_name }}" == *-alpha* || "${{ github.ref_name }}" == *-beta* || "${{ github.ref_name }}" == *-rc* ]]; then
-            echo "is_prerelease=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "is_prerelease=false" >> "$GITHUB_OUTPUT"
-          fi
 
       - name: Compute build args
         id: build_args
@@ -207,22 +307,8 @@ jobs:
           fi
           echo "args=$args" >> "$GITHUB_OUTPUT"
 
-      - name: Disable Apple app signing for macOS prerelease
-        if: ${{ contains(matrix.target, 'apple-darwin') && steps.release_flags.outputs.is_prerelease == 'true' }}
-        shell: bash
-        run: |
-          node - <<'NODE'
-          const fs = require("fs");
-          const path = "src-tauri/tauri.conf.json";
-          const conf = JSON.parse(fs.readFileSync(path, "utf8"));
-          if (conf.bundle && conf.bundle.macOS) {
-            delete conf.bundle.macOS.signingIdentity;
-          }
-          fs.writeFileSync(path, JSON.stringify(conf, null, 2));
-          NODE
-
       - name: Build Tauri app (signed/notarized)
-        if: steps.release_flags.outputs.is_prerelease != 'true'
+        if: steps.signing.outputs.should_sign == 'true'
         uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -235,10 +321,11 @@ jobs:
           APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
           APPLE_API_KEY_PATH: ~/.private_keys/AuthKey_${{ secrets.APPLE_API_KEY }}.p8
         with:
-          tagName: ${{ github.ref_name }}
-          releaseName: ClawPal ${{ github.ref_name }}
+          tagName: ${{ steps.release_meta.outputs.tag }}
+          releaseCommitish: ${{ inputs.target_commitish }}
+          releaseName: ClawPal ${{ steps.release_meta.outputs.tag }}
           releaseBody: |
-            ## ClawPal ${{ github.ref_name }}
+            ## ClawPal ${{ steps.release_meta.outputs.tag }}
 
             ${{ needs.changelog.outputs.body }}
 
@@ -262,18 +349,17 @@ jobs:
           prerelease: ${{ steps.release_flags.outputs.is_prerelease == 'true' }}
           args: ${{ steps.build_args.outputs.args }}
 
-      - name: Build Tauri app (prerelease)
-        if: steps.release_flags.outputs.is_prerelease == 'true'
+      - name: Build Tauri app (unsigned)
+        if: steps.signing.outputs.should_sign != 'true'
         uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
-          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         with:
-          tagName: ${{ github.ref_name }}
-          releaseName: ClawPal ${{ github.ref_name }}
+          tagName: ${{ steps.release_meta.outputs.tag }}
+          releaseCommitish: ${{ inputs.target_commitish }}
+          releaseName: ClawPal ${{ steps.release_meta.outputs.tag }} (unsigned)
           releaseBody: |
-            ## ClawPal ${{ github.ref_name }}
+            ## ClawPal ${{ steps.release_meta.outputs.tag }}
 
             ${{ needs.changelog.outputs.body }}
 
@@ -296,6 +382,48 @@ jobs:
           releaseDraft: true
           prerelease: ${{ steps.release_flags.outputs.is_prerelease == 'true' }}
           args: ${{ steps.build_args.outputs.args }}
+
+      - name: Rename release assets as unsigned
+        if: steps.signing.outputs.should_sign != 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          TAG="${{ steps.release_meta.outputs.tag }}"
+          BUNDLE_DIR="src-tauri/target/${{ matrix.target }}/release/bundle"
+          SUFFIX="${{ steps.signing.outputs.asset_suffix }}"
+
+          FILES=()
+          while IFS= read -r file; do
+            FILES+=("$file")
+          done < <(find "$BUNDLE_DIR" -type f \( \
+            -name "*.dmg" -o \
+            -name "*.deb" -o \
+            -name "*.AppImage" -o \
+            -name "*.msi" -o \
+            -name "*.exe" -o \
+            -name "*.rpm" \
+          \))
+
+          if [ ${#FILES[@]} -eq 0 ]; then
+            echo "::error::No bundle assets found to rename as unsigned"
+            exit 1
+          fi
+
+          mkdir -p unsigned-release-assets
+
+          for src in "${FILES[@]}"; do
+            base="$(basename "$src")"
+            if [[ "$base" == *.* ]]; then
+              unsigned_name="${base%.*}${SUFFIX}.${base##*.}"
+            else
+              unsigned_name="${base}${SUFFIX}"
+            fi
+
+            cp "$src" "unsigned-release-assets/$unsigned_name"
+            gh release upload "$TAG" "unsigned-release-assets/$unsigned_name" --clobber
+            gh release delete-asset "$TAG" "$base" -y || true
+          done
 
       - name: Upload Windows portable exe
         if: matrix.platform == 'windows-latest'
@@ -305,9 +433,9 @@ jobs:
         run: |
           $exe = Get-ChildItem "src-tauri/target/${{ matrix.target }}/release/clawpal.exe" -ErrorAction SilentlyContinue
           if ($exe) {
-            $dest = "ClawPal_portable_x64.exe"
+            $dest = "ClawPal_portable_x64${{ steps.signing.outputs.asset_suffix }}.exe"
             Copy-Item $exe.FullName $dest
-            gh release upload ${{ github.ref_name }} $dest --clobber
+            gh release upload "${{ steps.release_meta.outputs.tag }}" $dest --clobber
           }
 
       - name: Upload zeroclaw sidecar binary
@@ -342,6 +470,15 @@ jobs:
               ;;
           esac
 
+          ASSET_SUFFIX="${{ steps.signing.outputs.asset_suffix }}"
+          if [ -n "$ASSET_SUFFIX" ]; then
+            if [[ "$OUTPUT_NAME" == *.exe ]]; then
+              OUTPUT_NAME="${OUTPUT_NAME%.exe}${ASSET_SUFFIX}.exe"
+            else
+              OUTPUT_NAME="${OUTPUT_NAME}${ASSET_SUFFIX}"
+            fi
+          fi
+
           SOURCE="src-tauri/resources/zeroclaw/${SIDE_DIR}/${SOURCE_BIN}"
           if [ ! -f "$SOURCE" ]; then
             echo "Zeroclaw binary not found for ${SIDE_DIR}: $SOURCE"
@@ -354,7 +491,7 @@ jobs:
           if [ "${{ matrix.platform }}" != "windows-latest" ]; then
             chmod +x "$DEST"
           fi
-          gh release upload ${{ github.ref_name }} "$DEST" --clobber
+          gh release upload "${{ steps.release_meta.outputs.tag }}" "$DEST" --clobber
 
       - name: Cleanup Apple signing (macOS only)
         if: ${{ contains(matrix.target, 'apple-darwin') && always() }}

--- a/docs/release-prerelease-workflow.md
+++ b/docs/release-prerelease-workflow.md
@@ -1,0 +1,138 @@
+# ClawPal Release / Prerelease 流程说明
+
+本文基于当前仓库 `.github/workflows/bump-version.yml` 与 `.github/workflows/release.yml`（2026-03-04）整理，说明 `release` 与 `prerelease` 的实际执行流程，以及 Apple Developer 签名/公证行为。
+
+## 1. 触发入口（推荐）
+
+推荐通过 `Bump Version` workflow（手动触发）作为统一入口：
+
+1. 校验目标版本（严格 semver + tag 冲突检查）
+2. 更新代码版本（`package.json` / `src-tauri/Cargo.toml` / `src-tauri/Cargo.lock`）
+3. 运行测试 CI（前端 typecheck/build + Rust fmt/clippy/test）
+4. 运行打包 CI（4 平台矩阵，验证可打包）
+5. 全部通过后才执行 commit + push（不打 tag）
+6. `Bump Version` 直接 dispatch `Release` workflow 创建/更新 Draft Release
+7. 人工审核后点击 Publish，GitHub 才会创建 `vX.Y.Z` tag
+
+## 2. Release Workflow 触发条件
+
+- Workflow: `Release`
+- 触发事件: `workflow_dispatch`（由 `Bump Version` 触发）
+- 输入:
+  - `version`
+  - `target_commitish`
+  - `is_prerelease`
+- 示例:
+  - 正式版: `v0.1.1`
+  - 预发布: `v0.1.1-beta.1` / `v0.1.1-rc.1`
+
+## 3. 总体结构
+
+`Release` workflow 包含两个 job：
+
+1. `changelog`（Ubuntu）  
+   读取 `target_commitish` 与上一个 tag 之间的提交，按 `feat` / `fix` / 其他分组，产出 `needs.changelog.outputs.body`。
+2. `build`（矩阵构建）  
+   并行构建 4 个目标平台：
+   - `aarch64-apple-darwin`（macOS-ARM64）
+   - `x86_64-apple-darwin`（macOS-x64）
+   - `x86_64-unknown-linux-gnu`（Linux-x64）
+   - `x86_64-pc-windows-msvc`（Windows-x64）
+
+## 4. `build` job 详细流程（release 与 prerelease 共用）
+
+每个矩阵目标执行以下步骤：
+
+1. `actions/checkout@v4`
+2. `actions/setup-node@v4`（Node 20）
+3. `dtolnay/rust-toolchain@stable`
+4. `swatinem/rust-cache@v2`
+5. 从 workflow 输入 `version` 同步版本号到 `package.json` 与 `src-tauri/Cargo.toml`
+6. 根据 `is_prerelease` 自动选择 environment：
+   - 无 `-` 后缀：`release`
+   - 有 `-` 后缀：`prerelease`
+7. 检测签名 secrets 是否齐全，判定 `signed/unsigned` 模式
+8. 若 unsigned：自动关闭 updater artifacts 和 macOS signing identity
+9. Linux 目标安装系统依赖（仅 `ubuntu-22.04`）
+10. signed 模式下才执行 Apple 证书导入与 API key 写入（macOS）
+11. `npm ci`
+12. 计算构建参数（Windows prerelease 追加 `--bundles nsis`）
+13. 执行 Tauri 打包（signed 或 unsigned 路径）
+14. unsigned 模式将 release 资产重命名为 `*-unsigned.*`
+15. 上传 Windows portable 与 `zeroclaw` sidecar（unsigned 模式同样加后缀）
+16. macOS 清理临时 keychain 与 API key 文件
+
+## 5. Release 与 Prerelease 的差异
+
+两者流程主体一致，差异点如下：
+
+1. GitHub Release 元数据
+   - `prerelease: false`（正式版）
+   - `prerelease: true`（预发布）
+
+2. 绑定的 environment
+   - `release`（通常对应稳定版本 tag）
+   - `prerelease`（通常对应带预发布后缀 tag）
+
+3. Windows 打包参数
+   - prerelease 下会额外加 `--bundles nsis`
+   - 正式版不加这个额外参数（维持默认 bundles）
+
+4. tag 命名约定
+   - 正式版一般为 `vX.Y.Z`
+   - 预发布一般为 `vX.Y.Z-alpha.N / beta.N / rc.N`
+
+## 6. 签名决策逻辑（关键）
+
+签名由 secrets 是否齐全决定，而不是仅看 release/prerelease：
+
+关键点：
+
+1. 同时满足以下 secrets 时进入 signed 模式：
+   - `TAURI_SIGNING_PRIVATE_KEY`
+   - `TAURI_SIGNING_PRIVATE_KEY_PASSWORD`
+   - `APPLE_CERTIFICATE`
+   - `APPLE_CERTIFICATE_PASSWORD`
+   - `APPLE_SIGNING_IDENTITY`
+   - `APPLE_API_KEY`
+   - `APPLE_API_ISSUER`
+   - `APPLE_API_KEY_CONTENT`
+2. 只要任一缺失，自动进入 unsigned 模式：
+   - 不做 Apple 导入/公证步骤
+   - Tauri 配置自动关闭签名相关设置
+   - 上传产物名追加 `-unsigned`
+3. signed 模式保持原命名（不加后缀）
+
+## 7. 必需 Secrets（发布签名相关）
+
+若希望发布为 signed，至少需要：
+
+1. `TAURI_SIGNING_PRIVATE_KEY`
+2. `TAURI_SIGNING_PRIVATE_KEY_PASSWORD`
+3. `APPLE_CERTIFICATE`
+4. `APPLE_CERTIFICATE_PASSWORD`
+5. `APPLE_SIGNING_IDENTITY`
+6. `APPLE_API_KEY`
+7. `APPLE_API_ISSUER`
+8. `APPLE_API_KEY_CONTENT`
+
+缺少任意一个不会直接失败，而是自动降级为 unsigned 构建并在资产名上标记。
+
+## 8. 与其他 Workflow 的签名行为对比
+
+1. `pr-build.yml`  
+   明确是 **unsigned development builds**（用于 PR 测试，不是发布签名产物）。
+2. `ci.yml` / `e2e.yml` / `coverage.yml` / `bump-version.yml`  
+   无 Apple Developer 签名流程。
+
+## 9. 典型发布操作建议
+
+1. 先确认版本号与 tag 语义
+   - 正式版: `vX.Y.Z`
+   - 预发布: `vX.Y.Z-beta.N`
+2. 手动触发 `Bump Version`，选择 `patch/minor/major/custom`
+3. 等待 `Bump Version` 的 `Test CI` 与 `Package CI` 全部通过
+4. 确认 `Commit and Trigger Draft Release` 成功（此时尚未创建 git tag）
+5. 在 `Release` workflow 中核对 4 平台矩阵构建
+6. 在 draft release 中验证产物、签名和说明
+7. 点击 Publish（此时 GitHub 创建 `vX.Y.Z` tag 并正式发布）


### PR DESCRIPTION
## Summary
- refactor `Bump Version` into a gated pipeline that validates version, runs tests, runs package CI, then commits and dispatches `Release`
- switch `Release` to `workflow_dispatch` (inputs: `version`, `target_commitish`, `is_prerelease`) so draft creation no longer requires pre-pushed tags
- add signing material detection tied to `release`/`prerelease` environments and auto-fallback to unsigned builds when secrets are incomplete
- append `-unsigned` to release artifact names when unsigned mode is used
- add/update release process documentation in `docs/release-prerelease-workflow.md`

## Why
- aligns with the requested flow: review draft first, and only create git tag when the draft is published
- avoids hard failures when signing secrets are unavailable in the selected environment
- makes signed vs unsigned artifacts explicit for consumers

## Validation
- YAML parse check for workflows (`bump-version.yml`, `release.yml`)
