### PR TITLE
fix: prevent tab close crash when closing active instance

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -32,6 +32,7 @@ import type { ChannelNode, DiscordGuildChannel, DiscoveredInstance, DockerInstan
 import { GuidanceCard } from "./components/GuidanceCard";
 import { SshFormWidget } from "./components/SshFormWidget";
 import type { AgentGuidanceItem } from "./components/GuidanceCard";
+import { closeWorkspaceTab, shouldRenderGuidanceCard } from "@/lib/tabWorkspace";
 import {
   SSH_PASSPHRASE_RETRY_HINT,
   buildSshPassphraseCancelMessage,
@@ -943,19 +944,19 @@ export function App() {
   }, [navigateRoute]);
 
   const closeTab = useCallback((id: string) => {
-    setOpenTabIds((prev) => {
-      const next = prev.filter((t) => t !== id);
-      if (activeInstance === id) {
-        if (next.length === 0) {
-          setInStart(true);
-          setStartSection("overview");
-        } else {
-          setActiveInstance(next[next.length - 1]);
-        }
-      }
-      return next;
+    setOpenTabIds((prevOpenTabIds) => {
+      const nextState = closeWorkspaceTab({
+        openTabIds: prevOpenTabIds,
+        activeInstance,
+        inStart,
+        startSection,
+      }, id);
+      setActiveInstance(nextState.activeInstance);
+      setInStart(nextState.inStart);
+      setStartSection(nextState.startSection);
+      return nextState.openTabIds;
     });
-  }, [activeInstance]);
+  }, [activeInstance, inStart, startSection]);
 
   const handleInstanceSelect = useCallback((id: string) => {
     if (id === activeInstance && !inStart) {
@@ -1802,7 +1803,7 @@ export function App() {
         className="fixed bottom-5 z-[60] flex flex-col items-end gap-2"
         style={{ right: chatPanelRightOffset }}
       >
-        {agentGuidanceOpen && (
+        {shouldRenderGuidanceCard(agentGuidanceOpen, agentGuidance) && (
           <GuidanceCard
             guidance={agentGuidance}
             instanceLabel={

--- a/src/lib/__tests__/tabWorkspace.test.ts
+++ b/src/lib/__tests__/tabWorkspace.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  closeWorkspaceTab,
+  shouldRenderGuidanceCard,
+} from "../tabWorkspace";
+
+describe("closeWorkspaceTab", () => {
+  test("closes inactive tab without changing active instance", () => {
+    const result = closeWorkspaceTab({
+      openTabIds: ["local", "docker:a", "ssh:b"],
+      activeInstance: "docker:a",
+      inStart: false,
+      startSection: "overview",
+    }, "ssh:b");
+
+    expect(result.openTabIds).toEqual(["local", "docker:a"]);
+    expect(result.activeInstance).toBe("docker:a");
+    expect(result.inStart).toBe(false);
+  });
+
+  test("when closing active tab, switches to the last remaining tab", () => {
+    const result = closeWorkspaceTab({
+      openTabIds: ["local", "docker:a", "ssh:b"],
+      activeInstance: "ssh:b",
+      inStart: false,
+      startSection: "overview",
+    }, "ssh:b");
+
+    expect(result.openTabIds).toEqual(["local", "docker:a"]);
+    expect(result.activeInstance).toBe("docker:a");
+    expect(result.inStart).toBe(false);
+  });
+
+  test("when closing last tab, enters start mode and resets section", () => {
+    const result = closeWorkspaceTab({
+      openTabIds: ["ssh:b"],
+      activeInstance: "ssh:b",
+      inStart: false,
+      startSection: "profiles",
+    }, "ssh:b");
+
+    expect(result.openTabIds).toEqual([]);
+    expect(result.inStart).toBe(true);
+    expect(result.startSection).toBe("overview");
+    expect(result.activeInstance).toBe("local");
+  });
+});
+
+describe("shouldRenderGuidanceCard", () => {
+  test("requires guidance payload even when panel is open", () => {
+    expect(shouldRenderGuidanceCard(true, null)).toBe(false);
+  });
+
+  test("renders only when open and guidance exists", () => {
+    expect(shouldRenderGuidanceCard(false, { instanceId: "local" })).toBe(false);
+    expect(shouldRenderGuidanceCard(true, { instanceId: "local" })).toBe(true);
+  });
+});

--- a/src/lib/tabWorkspace.ts
+++ b/src/lib/tabWorkspace.ts
@@ -1,0 +1,39 @@
+export interface WorkspaceTabState {
+  openTabIds: string[];
+  activeInstance: string;
+  inStart: boolean;
+  startSection: "overview" | "profiles" | "settings";
+}
+
+export function closeWorkspaceTab(state: WorkspaceTabState, id: string): WorkspaceTabState {
+  if (!state.openTabIds.includes(id)) return state;
+
+  const openTabIds = state.openTabIds.filter((tabId) => tabId !== id);
+  const isClosingActive = state.activeInstance === id;
+  const activeInstance = isClosingActive
+    ? (openTabIds[openTabIds.length - 1] ?? "local")
+    : state.activeInstance;
+
+  if (openTabIds.length === 0) {
+    return {
+      ...state,
+      openTabIds,
+      activeInstance,
+      inStart: true,
+      startSection: "overview",
+    };
+  }
+
+  return {
+    ...state,
+    openTabIds,
+    activeInstance,
+  };
+}
+
+export function shouldRenderGuidanceCard<T>(
+  guidanceOpen: boolean,
+  guidance: T | null,
+): guidance is T {
+  return guidanceOpen && guidance !== null;
+}


### PR DESCRIPTION
## Summary
- fix tab close state transition via a dedicated closeWorkspaceTab helper
- guard GuidanceCard rendering to require both agentGuidanceOpen and non-null guidance payload
- add regression tests for active-tab close behavior and guidance render guard

## Verification
- bun test src/lib/__tests__/tabWorkspace.test.ts
- bun test src/lib/__tests__
- bun run typecheck