### PR TITLE
fix: make doctor diagnostics user-friendly

### DIFF
--- a/prompts/doctor/domain-system.md
+++ b/prompts/doctor/domain-system.md
@@ -5,6 +5,10 @@
 DOCTOR DOMAIN ONLY.
 You are ClawPal Doctor assistant.
 Always respond in {{language_rule}}.
+For non-technical users, write in conversational style.
+Avoid product/engineering jargon (for example: orchestration, transport, binary, binary path, instance state machine).
+Explain what the issue means in plain words first, then give next concrete steps.
+If a step is technical, still tell the user the impact and the simplest action in simple language.
 Identity rule: you are Doctor Claw (engine), not the target host.
 If user asks who/where you are, include both engine and target instance id.
 Do NOT infer transport type from instance name pattern.

--- a/prompts/doctor/history-preamble.md
+++ b/prompts/doctor/history-preamble.md
@@ -4,6 +4,9 @@
 ```prompt
 You are continuing a Doctor troubleshooting chat. Keep continuity with prior turns.
 Keep responding in the same language selected for this diagnosis session.
+Keep it conversational and beginner-friendly.
+When describing issues, use plain language and avoid technical wording unless unavoidable.
+For every reply, explain what happened in simple terms first, then a clear next action.
 You can ONLY use `clawpal` and `openclaw` tools.
 If command execution is needed, output ONLY one JSON object in this exact shape:
 {"tool":"clawpal","args":"<subcommand>","reason":"<why>"}

--- a/prompts/frontend/doctor-start.md
+++ b/prompts/frontend/doctor-start.md
@@ -4,6 +4,9 @@
 ```prompt
 You are ClawPal's diagnostic assistant powered by Doctor Claw. Respond in {{language}}.
 Identity rule: you are Doctor Claw (the diagnosing engine), not the target machine itself.
+Use conversational wording for non-technical users. Keep it short.
+If the user language is Chinese, explain by concrete effects first, then practical next steps.
+Avoid jargon like "execution path", "transport", and "tooling".
 When asked who/where you are, always state both: engine=Doctor Claw, target=<current target>.
 {{transport_line}}
 

--- a/src-tauri/src/agent_fallback.rs
+++ b/src-tauri/src/agent_fallback.rs
@@ -98,10 +98,10 @@ fn rules_fallback(
                     .to_string(),
             actions: vec![
                 "重新进入该实例并等待 1-2 秒后自动刷新。".to_string(),
-                "若仍失败，打开 Doctor 让 Agent继续执行更细粒度修复。".to_string(),
+                "若仍失败，打开 Doctor 让 AI 继续帮你排查并给下一步建议。".to_string(),
             ],
             structured_actions: vec![GuidanceAction {
-                label: "让小龙虾修复".to_string(),
+                label: "让 AI 继续排查".to_string(),
                 action_type: "doctor_handoff".to_string(),
                 tool: None,
                 args: None,
@@ -124,7 +124,7 @@ fn rules_fallback(
                 "如需更换密钥，前往能力档案页面更新对应的 Provider 配置。".to_string(),
             ],
             structured_actions: vec![GuidanceAction {
-                label: "让小龙虾修复".to_string(),
+                label: "让 AI 继续排查".to_string(),
                 action_type: "doctor_handoff".to_string(),
                 tool: None,
                 args: None,
@@ -143,10 +143,10 @@ fn rules_fallback(
             summary: "实例对应的 Docker 容器已不存在，可能已被手动删除。".to_string(),
             actions: vec![
                 "重新安装该实例，或从实例列表中移除。".to_string(),
-                "打开 Doctor 页面让小龙虾诊断并修复。".to_string(),
+                "打开 Doctor 页面让 AI 继续排查并修复。".to_string(),
             ],
             structured_actions: vec![GuidanceAction {
-                label: "让小龙虾修复".to_string(),
+                label: "让 AI 继续排查".to_string(),
                 action_type: "doctor_handoff".to_string(),
                 tool: None,
                 args: None,
@@ -183,12 +183,12 @@ fn rules_fallback(
             actions.push("在目标实例执行 openclaw 安装/修复脚本，并重新登录 shell。".to_string());
             actions.push("确认 `command -v openclaw` 可返回路径后，再重试当前操作。".to_string());
         }
-        actions.push("进入 Doctor 页面并点击诊断，让内置 Agent 继续自动排查。".to_string());
+        actions.push("进入 Doctor 页面点击“继续诊断”，让 AI 自动帮你继续排查。".to_string());
         return GuidanceBody {
             summary,
             actions,
             structured_actions: vec![GuidanceAction {
-                label: "让小龙虾修复".to_string(),
+                label: "让 AI 继续排查".to_string(),
                 action_type: "doctor_handoff".to_string(),
                 tool: None,
                 args: None,
@@ -204,10 +204,10 @@ fn rules_fallback(
                 "确认 ~/.ssh/config 里的 User 与目标实例实际登录用户一致（例如 root 账号通常被禁用）。".to_string(),
                 "确认对应 IdentityFile 的公钥已写入远端 ~/.ssh/authorized_keys。".to_string(),
                 "可先在终端运行 `ssh <alias>` 验证后再返回重试。".to_string(),
-                "若仍失败，请先打开 Doctor 页面执行自动诊断并按建议修复。".to_string(),
+                "若仍失败，请先打开 Doctor 页面执行自动诊断并按建议继续处理。".to_string(),
             ],
             structured_actions: vec![GuidanceAction {
-                label: "让小龙虾修复".to_string(),
+                label: "让 AI 继续排查".to_string(),
                 action_type: "doctor_handoff".to_string(),
                 tool: None,
                 args: None,
@@ -241,7 +241,7 @@ fn rules_fallback(
             actions: vec![
                 format!("先在实例页重连 {target_hint} 的 SSH 并确认网络可达。"),
                 "执行一次健康检查，确认网关和配置目录可访问。".to_string(),
-                "若仍失败，请先打开 Doctor 页面执行自动诊断并按建议修复。".to_string(),
+                "若仍失败，请先打开 Doctor 页面执行自动诊断并按建议继续处理。".to_string(),
             ],
             structured_actions: vec![
                 GuidanceAction {
@@ -253,7 +253,7 @@ fn rules_fallback(
                     context: None,
                 },
                 GuidanceAction {
-                    label: "让小龙虾修复".to_string(),
+                    label: "让 AI 继续排查".to_string(),
                     action_type: "doctor_handoff".to_string(),
                     tool: None,
                     args: None,
@@ -271,7 +271,7 @@ fn rules_fallback(
             "按诊断结果优先处理阻塞项后，再重试当前操作。".to_string(),
         ],
         structured_actions: vec![GuidanceAction {
-            label: "让小龙虾修复".to_string(),
+            label: "让 AI 继续排查".to_string(),
             action_type: "doctor_handoff".to_string(),
             tool: None,
             args: None,
@@ -473,7 +473,7 @@ mod tests {
     #[test]
     fn guidance_action_serializes_doctor_handoff() {
         let action = GuidanceAction {
-            label: "让小龙虾修复".to_string(),
+            label: "让 AI 继续排查".to_string(),
             action_type: "doctor_handoff".to_string(),
             tool: None,
             args: None,

--- a/src-tauri/src/prompt_templates.rs
+++ b/src-tauri/src/prompt_templates.rs
@@ -86,6 +86,8 @@ mod tests {
         assert!(prompt.contains("If `docGuidance` exists in context"));
         assert!(prompt.contains("root_cause_hypothesis"));
         assert!(prompt.contains("version_awareness"));
+        assert!(prompt.contains("non-technical"));
+        assert!(prompt.contains("plain words"));
     }
 
     #[test]
@@ -111,6 +113,7 @@ mod tests {
         assert!(prompt.contains("root_cause_hypothesis"));
         assert!(prompt.contains("docGuidance"));
         assert!(prompt.contains("citations"));
+        assert!(prompt.contains("beginner-friendly"));
     }
 
     #[test]

--- a/src-tauri/src/runtime/zeroclaw/adapter.rs
+++ b/src-tauri/src/runtime/zeroclaw/adapter.rs
@@ -46,6 +46,10 @@ impl ZeroclawDoctorAdapter {
         )
     }
 
+    fn looks_like_chinese(message: &str) -> bool {
+        Self::infer_language_rule(message) == "Simplified Chinese (简体中文)"
+    }
+
     fn normalize_doctor_output(raw: String) -> String {
         let trimmed = raw.trim();
         let mut candidates = vec![trimmed.to_string()];
@@ -59,9 +63,16 @@ impl ZeroclawDoctorAdapter {
                 let step = v.get("step").and_then(|x| x.as_str());
                 let reason = v.get("reason").and_then(|x| x.as_str());
                 if step.is_some() && reason.is_some() {
+                    let reason = reason.unwrap_or("先做一次快速排查，再继续。").trim();
+                    if Self::looks_like_chinese(reason) {
+                        return format!(
+                            "我先把这次会话当作“诊断模式”处理：只负责先检查和给建议，不会直接改配置。下一步建议先{}。",
+                            reason
+                        );
+                    }
                     return format!(
-                        "当前是 Doctor 诊断模式，不执行安装编排。诊断建议：{}",
-                        reason.unwrap_or("请先收集错误日志并确认运行状态。")
+                        "I’m running in diagnosis-only mode: I’ll check first and suggest fixes, not make risky changes yet. Next suggestion: {}",
+                        reason
                     );
                 }
             }
@@ -86,7 +97,8 @@ impl ZeroclawDoctorAdapter {
         let intent = crate::runtime::zeroclaw::tool_intent::parse_tool_intent(raw)?;
         let reason = intent
             .reason
-            .unwrap_or_else(|| "需要执行命令以继续诊断。".to_string());
+            .unwrap_or_else(|| "先跑一条检查命令，确认问题点。".to_string());
+        let friendly_reason = reason.trim();
         let invoke_type =
             crate::runtime::zeroclaw::tool_intent::classify_invoke_type(&intent.tool, &intent.args);
         let payload = json!({
@@ -98,12 +110,24 @@ impl ZeroclawDoctorAdapter {
             },
             "type": invoke_type,
         });
-        let note = format!(
-            "建议执行诊断命令：`{} {}`\n原因：{}",
+        let raw_cmd = format!(
+            "{} {}",
             payload["command"].as_str().unwrap_or(""),
-            payload["args"]["args"].as_str().unwrap_or(""),
-            reason
+            payload["args"]["args"].as_str().unwrap_or("")
         );
+        let note = if Self::looks_like_chinese(friendly_reason) {
+            format!(
+                "我先跑一条检查命令：`{}`，方便确认当前问题。原因：{}",
+                raw_cmd.trim(),
+                friendly_reason
+            )
+        } else {
+            format!(
+                "I will run one diagnostic command: `{}`, because {}. So we can confirm what’s blocking things.",
+                raw_cmd.trim(),
+                friendly_reason
+            )
+        };
         Some((RuntimeEvent::Invoke { payload }, note))
     }
 
@@ -203,6 +227,36 @@ mod tests {
             parsed.is_some(),
             "should parse tool JSON even if another JSON appears first"
         );
+    }
+
+    #[test]
+    fn normalize_doctor_output_prefers_friendly_chinese() {
+        let raw = r#"{"step":"x","reason":"先收集日志再确认错误点"}"#;
+        let parsed = ZeroclawDoctorAdapter::normalize_doctor_output(raw.to_string());
+        assert!(parsed.contains("诊断模式"));
+        assert!(parsed.contains("先收集日志"));
+        assert!(!parsed.contains("不执行安装编排"));
+    }
+
+    #[test]
+    fn normalize_doctor_output_prefers_friendly_english() {
+        let raw = r#"{"step":"x","reason":"check gateway logs to confirm error context."}"#;
+        let parsed = ZeroclawDoctorAdapter::normalize_doctor_output(raw.to_string());
+        assert!(parsed.contains("diagnosis-only mode"));
+        assert!(parsed.contains("check gateway logs"));
+    }
+
+    #[test]
+    fn parse_tool_intent_note_is_user_friendly() {
+        let raw = r#"我先说明一下。{"tool":"clawpal","args":"health check --all","reason":"确认服务是否启动"}"#;
+        let parsed = ZeroclawDoctorAdapter::parse_tool_intent(raw);
+        assert!(
+            parsed.is_some(),
+            "should parse tool intent and provide friendly note"
+        );
+        let (_invoke, note) = parsed.unwrap();
+        assert!(note.contains("我先跑一条检查命令"));
+        assert!(!note.contains("建议执行诊断命令"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- 让 Doctor（zeroclaw）面向非技术用户的诊断输出更口语化，减少“工程术语”堆叠。
- 对诊断会话与执行路径提示词添加防技化引导：先说“发生了什么”，再给可执行下一步。
- 调整运行时中间态文案和 fallback 引导，避免出现“安装编排/建议执行诊断命令”等高技术术语。
- 更新相关单测，验证文案约束与英文/中文分支都生效。

## Changes
### 1) Prompt 升级（非技术化约束）
- `prompts/doctor/domain-system.md`
- `prompts/doctor/history-preamble.md`
- `prompts/frontend/doctor-start.md`

### 2) Runtime 文案标准化
- `src-tauri/src/runtime/zeroclaw/adapter.rs`
  - 优化 `normalize_doctor_output` 诊断模式提示文案
  - 优化 `parse_tool_intent` 的 tool intent 提示文案
  - 新增中文/英文友好文案单测

### 3) Fallback 文案优化
- `src-tauri/src/agent_fallback.rs`
  - 统一“让 AI 继续排查”相关动作文案（去除小龙虾人设式术语）
  - 更新结构化按钮文案对应测试

### 4) Prompt 测试约束
- `src-tauri/src/prompt_templates.rs`
  - 增加对 `non-technical` / `plain words` / `beginner-friendly` 的断言

## Verification
- `cargo test -p clawpal --lib`
  - 219 passed, 0 failed
- `bun test`
  - 175 pass, 0 fail

## Acceptance Criteria
- [ ] 中文诊断回复显著降低工程术语出现频率，先解释“当前影响”，再给“下一步”。
- [ ] 用户在 Doctor/诊断流程中的关键交互文案更口语化。
- [ ] 无回归：现有单测全部通过。
- [ ] 无新增业务逻辑分支导致行为变更，仅为文案与约束层增强。

## Notes / Risks
- 该改动主要集中在 prompt/文案层，行为规则（工具调用白名单、执行链路）保持不变；对可执行动作无功能性影响。
